### PR TITLE
Lint Ansible playbooks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint Playbook
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Lint Ansible playbooks
+        uses: ansible/ansible-lint-action@master
+        with:
+          targets: |
+            playbook.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,3 +19,5 @@ jobs:
         with:
           targets: |
             playbook.yml
+          override-deps: |
+            ansible-lint==5.3.2


### PR DESCRIPTION
This uses the [`ansible/ansible-lint-action`](https://github.com/ansible/ansible-lint-action) GitHub Action to lint playbooks.