### PR TITLE
Resolve FQDNs in /etc/hosts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ansible
 ansible-lint[yamllint]
 pre-commit
+dnspython

--- a/roles/common/templates/etc-hosts.j2
+++ b/roles/common/templates/etc-hosts.j2
@@ -4,4 +4,4 @@
 ::1     localhost ip6-localhost ip6-loopback
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
-{{ ansible_host }}    {{ inventory_hostname }}.box.pydis.wtf {{ inventory_hostname }}
+{{ lookup('dig', ansible_host) }}    {{ inventory_hostname }}.box.pydis.wtf {{ inventory_hostname }}


### PR DESCRIPTION
PR #8 swapped from hardcoded IPs in the Ansible Inventory to using FQDNs on `pydis.wtf`. This change worked fine and does the exact same thing from an Ansible side, but we were using the `ansible_host` variable in the /etc/hosts template file controlled by the common role.

This meant that when templated instead of receiving an IP where it expected an IP it received an FQDN, leading to an invalid /etc/hosts file being templated to the servers. This change fixes that by resolving the `pydis.wtf` FQDN (e.g. `turing.box.pydis.wtf`) to it's resulting A record, and then injects that to the configuration file (the FQDN is injected afterwards anyway as is expected with /etc/hosts)