### PR TITLE
Inject extra public keys for DevOps members

### DIFF
--- a/roles/wireguard/defaults/main/vars.yml
+++ b/roles/wireguard/defaults/main/vars.yml
@@ -1,0 +1,4 @@
+extra_keys:
+  - name: Joe
+    pubkey: /dJ+tKXzxv7nrUleNlF+CGyq7OIVlqL8/9Sn8j+cEAc=
+    subnet: 10.0.1.0/24

--- a/roles/wireguard/templates/wg0.conf.j2
+++ b/roles/wireguard/templates/wg0.conf.j2
@@ -13,3 +13,11 @@ Endpoint = {{ host }}.box.pydis.wtf:46850
 PersistentKeepalive = 30
 
 {% endfor %}
+
+{% for key in extra_keys %}
+# DevOps config for: {{ key.name }}
+[Peer]
+AllowedIPs = {{ key.subnet }}
+PublicKey = {{ key.pubkey }}
+
+{% endfor %}


### PR DESCRIPTION
This PR adds a variables file to the `wireguard` role and injects the keys as extra peers to the servers generated wireguard configurations.

This means that with a config file locally that includes all servers you can access the internal `10.0.0.0/8` ranges that services will be hosted on.

We could add a script for generating private wireguard configurations by automatically fetching the keys of the production servers.