### PR TITLE
Add podman role and improve playbook organization

### DIFF
--- a/inventory.yaml
+++ b/inventory.yaml
@@ -15,5 +15,13 @@ all:
     neumann:
       ansible_host: neumann.box.pydis.wtf
       wireguard_subnet: 10.5.0.0/16
+
+  children:
+    podman:
+      hosts:
+        turing:
+        lovelace:
+        hopper:
+        ritchie:
   vars:
     wireguard_port: 46850

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,29 +1,17 @@
-- hosts: all
+- name: Deploy common services
+  hosts: all
   roles:
     - common
-  tags:
-    - common
-
-- hosts: all
-  roles:
     - jumpcloud
-  tags:
-    - jumpcloud
-
-- hosts: all
-  roles:
     - ufw
-  tags:
-    - ufw
-
-- hosts: all
-  roles:
-    - wireguard
-  tags:
     - wireguard
 
-- hosts: lovelace
+- name: Deploy podman to container service hosts
+  hosts: podman
   roles:
-    - postgres
-  tags:
+    - podman
+
+- name: Deploy our PostgreSQL database hosts
+  hosts: lovelace
+  roles:
     - postgres

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,6 +1,8 @@
 - name: Update hostname to match Ansible inventory
   hostname:
     name: "{{ inventory_hostname }}"
+  tags:
+    - role::common
 
 - name: Update /etc/hosts to match Ansible inventory
   template:
@@ -9,6 +11,8 @@
     mode: '0644'
     owner: root
     group: root
+  tags:
+    - role::common
 
 - name: Disable SSH password authentication
   lineinfile:
@@ -18,6 +22,8 @@
     state: present
   notify:
     - restart ssh
+  tags:
+    - role::common
 
 - name: Set timezone to UTC
   file:
@@ -28,3 +34,5 @@
     group: root
   notify:
     - restart systemd-timesyncd
+  tags:
+    - role::common

--- a/roles/jumpcloud/tasks/main.yml
+++ b/roles/jumpcloud/tasks/main.yml
@@ -1,5 +1,7 @@
 - name: Fetch service facts
   service_facts:
+  tags:
+    - role::jumpcloud
 
 - name: Check if JumpCloud service is installed
   set_fact:
@@ -13,9 +15,13 @@
     return_content: true
   register: jc_install_script
   when: not jumpcloud_installed
+  tags:
+    - role::jumpcloud
 
 - name: Execute JumpCloud install script
   command: sh -s -- -y
   args:
     stdin: "{{ jc_install_script.content }}"
   when: not jumpcloud_installed
+  tags:
+    - role::jumpcloud

--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: install podman
+  package:
+    name: podman
+    state: present
+  tags:
+    - role::podman

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -6,21 +6,29 @@
       - postgresql-contrib-{{ postgresql_version }}
       - libpq-dev
     state: present
+  tags:
+    - role::postgres
 
 - name: Check postgres is started and enabled on boot.
   service:
     name: '{{ postgresql_daemon }}'
     state: started
     enabled: true
+  tags:
+    - role::postgres
 
 - name: Add postgres users.
   community.postgresql.postgresql_user: "{{ item }}"
   with_items: "{{ postgresql_users }}"
   become: true
   become_user: "{{ postgresql_user }}"
+  tags:
+    - role::postgres
 
 - name: Add postgres databases.
   community.postgresql.postgresql_db: "{{ item }}"
   with_items: "{{ postgresql_databases }}"
   become: true
   become_user: "{{ postgresql_user }}"
+  tags:
+    - role::postgres

--- a/roles/ufw/tasks/main.yml
+++ b/roles/ufw/tasks/main.yml
@@ -4,16 +4,22 @@
     cache_valid_time: 3600
     pkg:
       - ufw
+  tags:
+    - role::ufw
 
 - name: Allow OpenSSH
   community.general.ufw:
     rule: allow
     name: OpenSSH
+  tags:
+    - role::ufw
 
 - name: Enable UFW and deny all traffic by default
   community.general.ufw:
     state: enabled
     policy: deny
+  tags:
+    - role::ufw
 
 - name: Allow WireGuard
   community.general.ufw:
@@ -21,7 +27,11 @@
     proto: udp
     port: "{{ wireguard_port }}"
     comment: "Allow WireGuard"
+  tags:
+    - role::ufw
 
 - name: Apply service-specific rules
   community.general.ufw: "{{ item }}"
   with_items: "{{ rules }}"
+  tags:
+    - role::ufw

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -6,18 +6,24 @@
       - wireguard
       - wireguard-tools
       - linux-headers-{{ ansible_kernel }}
+  tags:
+    - role::wireguard
 
 - name: Generate WireGuard private key
   shell: set -o pipefail && wg genkey > /etc/wireguard/key.priv
   args:
     executable: /bin/bash
     creates: /etc/wireguard/key.priv
+  tags:
+    - role::wireguard
 
 - name: Generate WireGuard public key
   shell: set -o pipefail && cat /etc/wireguard/key.priv | wg pubkey > /etc/wireguard/key.pub
   args:
     executable: /bin/bash
     creates: /etc/wireguard/key.pub
+  tags:
+    - role::wireguard
 
 - name: Ensure file permissions for keys set correctly
   file:
@@ -28,16 +34,22 @@
   with_items:
     - /etc/wireguard/key.priv
     - /etc/wireguard/key.pub
+  tags:
+    - role::wireguard
 
 - name: Fetch private key for all hosts
   slurp:
     src: /etc/wireguard/key.priv
   register: wg_priv_key
+  tags:
+    - role::wireguard
 
 - name: Fetch public key for all hosts
   slurp:
     src: /etc/wireguard/key.pub
   register: wg_pub_key
+  tags:
+    - role::wireguard
 
 - name: Generate WireGuard configuration file
   template:
@@ -48,9 +60,13 @@
     owner: root
   notify:
     - reload wg-quick
+  tags:
+    - role::wireguard
 
 - name: Start and enable the WireGuard service
   service:
     name: wg-quick@wg0
     enabled: true
     state: started
+  tags:
+    - role::wireguard


### PR DESCRIPTION
This PR adds a new podman role, see #18.

The playbook is merged into sections for each group of hosts that we
want to deploy to. To limit by role now, use tags, such as `-t
role::podman`.