### PR TITLE
Add PostUp directive for routing wg subnet

### DIFF
--- a/roles/wireguard/templates/wg0.conf.j2
+++ b/roles/wireguard/templates/wg0.conf.j2
@@ -4,6 +4,8 @@ Address = {{ wireguard_subnet }}
 ListenPort = {{ wireguard_port }}
 PrivateKey = {{ wg_priv_key['content'] | b64decode | trim }}
 
+PostUp = ip route add local {{ wireguard_subnet }} dev eth0
+
 {% for host in hostvars.keys() if not host == inventory_hostname %}
 # Peer config for: {{ host }}
 [Peer]


### PR DESCRIPTION
This PR adds a PostUp directive to the Wireguard config of all nodes to add the allocated /16 to the local routing table.

This means that hosts:
- Are aware that packets destined for these IPs should be captured by the Kernel, not ignored
- Allow services to bind to any IP address within their allocated /16

This does *not* include a PostDown directive since we do not want to lose the local routing should the Wireguard session go down, services should still be able to bind to relevant IPs even without Wireguard to prevent SPOF.