### PR TITLE
Configure GeoIP for moon phase support

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -16,6 +16,7 @@
   hosts: nginx
   roles:
     - nginx
+    - nginx-geoip
     - nginx-ufw
     - nginx-cloudflare-mtls
 

--- a/roles/nginx-geoip/meta/main.yml
+++ b/roles/nginx-geoip/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - nginx

--- a/roles/nginx-geoip/tasks/main.yml
+++ b/roles/nginx-geoip/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# ref https://packages.debian.org/bullseye/amd64/libnginx-mod-http-geoip/filelist
+# installed by default in debian nginx package, including "geoip-database" dep
+# see https://packages.debian.org/bullseye/amd64/geoip-database/filelist
+- name: configure the geoip module
+  copy:
+    # ref https://nginx.org/en/docs/http/ngx_http_geoip_module.html
+    content: geoip_country /usr/share/GeoIP/GeoIP.dat;
+    dest: /etc/nginx/conf.d/geoip.conf
+    owner: root
+    group: root
+    mode: 0444
+  tags:
+    - role::nginx-geoip
+  notify:
+    - reload the nginx service


### PR DESCRIPTION
In order to add moon phase support on the dark theme picker later, we
need to configure the GeoIP module included with nginx.

On Debian, the `nginx` package that we install installs `nginx-core`,
which in turn installs the GeoIP module and even a GeoIP country
database for us.