### PR TITLE
Initial h-asgi configuration

### DIFF
--- a/roles/h-asgi/tasks/main.yml
+++ b/roles/h-asgi/tasks/main.yml
@@ -6,8 +6,9 @@
     - container:
         name: h-asgi
         image: ghcr.io/vcokltfre/h:latest
-        mem_max: 25M
-        cpu_quota: 3%
         port: 8000:8000
+    - service:
+        # CPUQuota: 3%
+        # MemoryMax: 25M
   tags:
     - role::h-asgi

--- a/roles/h-asgi/tasks/main.yml
+++ b/roles/h-asgi/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Install h-asgi systemd file
+  include_role:
+    name: podman
+  vars:
+    - container:
+        name: h-asgi
+        image: ghcr.io/vcokltfre/h:latest
+        mem_max: 25M
+        cpu_quota: 3%
+        port: 8000:8000
+  tags:
+    - role::h-asgi

--- a/roles/podman/handlers/main.yml
+++ b/roles/podman/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: reload systemd
+  systemd:
+    daemon_reload: true

--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -1,7 +1,27 @@
 ---
-- name: install podman
+- name: Ensure package is installed
   package:
     name: podman
     state: present
+  tags:
+    - role::podman
+
+- name: Ensure systemd service is present
+  template:
+    src: templates/container-.service.j2
+    dest: "/etc/systemd/system/container-{{ container.name }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - reload systemd
+  tags:
+    - role::podman
+
+- name: Ensure the systemd service is started and enabled
+  systemd:
+    name: "container-{{ container.name }}.service"
+    state: started
+    enabled: true
   tags:
     - role::podman

--- a/roles/podman/templates/container-.service.j2
+++ b/roles/podman/templates/container-.service.j2
@@ -1,0 +1,42 @@
+# vi: ft=systemd
+[Unit]
+Description = Podman container service for {{ container.name }}
+Wants=network-online.target
+After=network-online.target
+RequiresMountsFor=/var/run/container/storage
+
+[Service]
+Environment=PODMAN_SYSTEMD_UNIT=%n
+Type = forking
+
+PIDFile=%t/%n-pid
+Restart=on-failure
+RuntimeDirectory= %n
+
+ExecStartPre = /bin/rm -f %t/%n-pid %t/%n-cid
+# QUESTION: Why two cgroups? This was taken from:
+# https://github.com/python-discord/infra/issues/18#issuecomment-1027307623
+# TODO: make publish can be looped over to get multiple
+# ports opened.
+# TODO: look into an alternative for publishing ports
+# to the host adapter. Had issues with ufw conflicting when
+# using --publish directly. See: https://stackoverflow.com/a/51741599
+ExecStart = /usr/bin/podman run \
+  --cgroups=no-conmon \
+  --cgroups=disabled \
+  --log-driver=journald \
+  --cidfile %t/%n-cid \
+  --conmon-pidfile %t/%n-pid \
+  --detach \
+  --name {{ container.name }} \
+  --publish {{ container.port }} \
+  {{ container.image }}
+ExecStop = /usr/bin/podman stop --ignore --cidfile %t/%n-cid
+ExecStopPost = /usr/bin/podman rm --ignore -f --cidfile %t/%n-cid
+
+# TODO: Low values make the OOM mad when initially downloading a package.
+# Downloading packages should likely be done at a different place
+# or as a ExecStartPre with higher limits on CPUQuota and MemoryMax.
+
+#CPUQuota = {{ container.cpu_quota }}
+#MemoryMax = {{ container.mem_max }}

--- a/roles/podman/templates/container-.service.j2
+++ b/roles/podman/templates/container-.service.j2
@@ -41,5 +41,6 @@ ExecStopPost = /usr/bin/podman rm --ignore -f --cidfile %t/%n-cid
 # Downloading packages should likely be done at a different place
 # or as a ExecStartPre with higher limits on CPUQuota and MemoryMax.
 
-#CPUQuota = {{ container.cpu_quota }}
-#MemoryMax = {{ container.mem_max }}
+{% for key, value in (service | default({}) or {}).items() -%}
+{{ key }}={{ value }}
+{% endfor -%}

--- a/roles/podman/templates/container-.service.j2
+++ b/roles/podman/templates/container-.service.j2
@@ -35,7 +35,8 @@ ExecStart = /usr/bin/podman run \
   {% endfor -%}
   {{ container.image }}
 ExecStop = /usr/bin/podman stop --ignore --cidfile %t/%n-cid
-ExecStopPost = /usr/bin/podman rm --ignore -f --cidfile %t/%n-cid
+ExecStopPost=/usr/bin/test -f %t/%n-cid
+ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%n-cid
 
 # TODO: Low values make the OOM mad when initially downloading a package.
 # Downloading packages should likely be done at a different place

--- a/roles/podman/templates/container-.service.j2
+++ b/roles/podman/templates/container-.service.j2
@@ -1,19 +1,19 @@
 # vi: ft=systemd
 [Unit]
-Description = Podman container service for {{ container.name }}
+Description=Podman container service for {{ container.name }}
 Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/container/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Type = forking
+Type=forking
 
 PIDFile=%t/%n-pid
 Restart=on-failure
-RuntimeDirectory= %n
+RuntimeDirectory=%n
 
-ExecStartPre = /bin/rm -f %t/%n-pid %t/%n-cid
+ExecStartPre=/bin/rm -f %t/%n-pid %t/%n-cid
 # QUESTION: Why two cgroups? This was taken from:
 # https://github.com/python-discord/infra/issues/18#issuecomment-1027307623
 # TODO: make publish can be looped over to get multiple
@@ -21,7 +21,7 @@ ExecStartPre = /bin/rm -f %t/%n-pid %t/%n-cid
 # TODO: look into an alternative for publishing ports
 # to the host adapter. Had issues with ufw conflicting when
 # using --publish directly. See: https://stackoverflow.com/a/51741599
-ExecStart = /usr/bin/podman run \
+ExecStart=/usr/bin/podman run \
   --cgroups=no-conmon \
   --cgroups=disabled \
   --log-driver=journald \
@@ -34,7 +34,7 @@ ExecStart = /usr/bin/podman run \
   {{ option }} \
   {% endfor -%}
   {{ container.image }}
-ExecStop = /usr/bin/podman stop --ignore --cidfile %t/%n-cid
+ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%n-cid
 ExecStopPost=/usr/bin/test -f %t/%n-cid
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%n-cid
 

--- a/roles/podman/templates/container-.service.j2
+++ b/roles/podman/templates/container-.service.j2
@@ -30,6 +30,9 @@ ExecStart = /usr/bin/podman run \
   --detach \
   --name {{ container.name }} \
   --publish {{ container.port }} \
+  {% for option in container.options | default([]) or [] -%}
+  {{ option }} \
+  {% endfor -%}
   {{ container.image }}
 ExecStop = /usr/bin/podman stop --ignore --cidfile %t/%n-cid
 ExecStopPost = /usr/bin/podman rm --ignore -f --cidfile %t/%n-cid

--- a/roles/podman/templates/container-.service.j2
+++ b/roles/podman/templates/container-.service.j2
@@ -22,7 +22,6 @@ ExecStartPre=/bin/rm -f %t/%n-pid %t/%n-cid
 # to the host adapter. Had issues with ufw conflicting when
 # using --publish directly. See: https://stackoverflow.com/a/51741599
 ExecStart=/usr/bin/podman run \
-  --cgroups=no-conmon \
   --cgroups=disabled \
   --log-driver=journald \
   --cidfile %t/%n-cid \


### PR DESCRIPTION
This is a basic setup for an h-asgi deployment. Me and @MarkKoz got as far as we could without access to any staging environment.

We found 2 major issues with trying to deploy h-asgi in this way. First being a possible issue around conflicting iptables rules with ufw and podman. Where a published port cannot be port forwarded easily. See: https://stackoverflow.com/a/51741599
This should not be an issue if we use only reverse proxies, like nginx. But is something to keep in mind as a possible issue if we ever need a podman container be exposed directly.

Second issue was how to properly implement podman containers in ansible. We did find a lot around how to set up with quotas and memory limits. But it could lead to issues with OOM nuking the download process for podman repeatedly, to the point it corrupts podman to segfault at any command. We can use the `Startup*=` limits to work around this issue and only download images in a `ExecStartPre` stage.

Finally, @jchristgit the template you linked has two cgroup definitions. As i have understood you cant stack these, but id like your word on your reason why you had written it like that before removing it.