### PR TITLE
Allow HTTP traffic through the firewall

### DIFF
--- a/roles/nginx-ufw/tasks/main.yml
+++ b/roles/nginx-ufw/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
-- name: allow https traffic through the firewall
+- name: allow http(s) traffic through the firewall
   ufw:
-    app: Nginx HTTPS
+    app: Nginx Full
     rule: allow
   tags:
     - role::nginx-ufw


### PR DESCRIPTION
Allow HTTP traffic in addition to HTTPS by switching to the "Nginx Full" ruleset