### PR TITLE
Add local testing setup utilizing Vagrant VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ requirements.txt                     # Python requirements
 ```
 
 ## Local Environment Setup
+
+To setup a local environment using VMs for testing, [Read here](./local_testing/README.md)
+
 1. Create a virtual environment: `python -m venv venv`
 1. Activate the virtual environment
    - Windows: `.\venv\Scripts\activate`

--- a/local_testing/.gitignore
+++ b/local_testing/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/local_testing/README.md
+++ b/local_testing/README.md
@@ -1,0 +1,46 @@
+# Testing Locally
+
+### Requirements
+
+- [Vagrant](https://developer.hashicorp.com/vagrant/docs/installation)
+- [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+
+## Get Started
+
+```shell
+vagrant up                  # This will take a while
+vagrant ssh                 # Get a shell, password=vagrant
+
+# inside control VM
+/vagrant/scripts/push-keys  # Push the control VM's ssh key to all nodes
+
+# run ansible
+ansible-playbook playbook.yml --inventory local_testing/hosts.yaml --user vagrant
+
+```
+
+Below are the IPs of the VMs on the VirtualBox network
+```yaml
+vms:
+- control: 192.168.56.1
+- hopper: 192.168.56.2
+- lovelace: 192.168.56.3
+- neumann: 192.168.56.4
+- richie: 192.168.56.5
+- turing: 192.168.56.6
+```
+
+
+# Fixes/Notes
+
+### There was an error when attempting to rsync a synced folder.
+
+```shell
+vagrant plugin install vagrant-vbguest
+```
+
+
+### Kernel module is not loaded
+```shell
+sudo modprobe vbox{drv,netadp,netflt}
+```

--- a/local_testing/README.md
+++ b/local_testing/README.md
@@ -15,8 +15,12 @@ vagrant ssh                 # Get a shell, password=vagrant
 /vagrant/scripts/push-keys  # Push the control VM's ssh key to all nodes
 
 # run ansible
+cd infra
+# if you're on Windows, the `infra` directory will be mounted with permissions set to 777
+# which ansible will reject as insecure
+# export the below environment variable to force anisble to accept the writable config
+# export ANSIBLE_CONFIG='/home/vagrant/infra/ansible.cfg'
 ansible-playbook playbook.yml --inventory local_testing/hosts.yaml --user vagrant
-
 ```
 
 Below are the IPs of the VMs on the VirtualBox network

--- a/local_testing/Vagrantfile
+++ b/local_testing/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure("2") do |config|
     config.vm.box_version = "202212.11.0"
     config.vm.provision "shell", inline: <<-SHELL
         apt-get update
-        apt-get install -y python3 python3-pip openssh-server
+        apt-get install -y python3 openssh-server
         systemctl enable ssh
     SHELL
 
@@ -16,7 +16,7 @@ Vagrant.configure("2") do |config|
             virtualbox__intnet: true
         control.vm.synced_folder "../", "/home/vagrant/infra"
         control.vm.provision "shell", inline: <<-SHELL
-            apt-get install -y sshpass
+            apt-get install -y sshpass python3-pip
         SHELL
 
         control.vm.provision "shell", privileged: false, inline: <<-SHELL

--- a/local_testing/Vagrantfile
+++ b/local_testing/Vagrantfile
@@ -1,0 +1,91 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+    config.vm.box = "bento/debian-11"
+    config.vm.box_version = "202212.11.0"
+    config.vm.provision "shell", inline: <<-SHELL
+        apt-get update
+        apt-get install -y python3 python3-pip openssh-server
+        systemctl enable ssh
+    SHELL
+
+    config.vm.define "control", primary: true do |control|
+        control.vm.hostname = "control"
+        control.vm.network "private_network", ip: "192.168.56.1",
+            virtualbox__intnet: true
+        control.vm.synced_folder "../", "/home/vagrant/infra"
+        control.vm.provision "shell", inline: <<-SHELL
+            apt-get install -y sshpass
+        SHELL
+
+        control.vm.provision "shell", privileged: false, inline: <<-SHELL
+            python3 -m pip install --user ansible dnspython
+            ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa <<< y
+        SHELL
+
+        control.vm.provider "virtualbox" do |v|
+          v.name = "pydis_control"
+        end
+    end
+
+    config.vm.define "hopper" do |hopper|
+        hopper.vm.hostname = "hopper"
+        hopper.vm.network "private_network", ip: "192.168.56.2",
+            virtualbox__intnet: true
+        hopper.vm.synced_folder '.', '/vagrant', disabled: true
+
+        hopper.vm.provider "virtualbox" do |v|
+          v.name = "pydis_hopper"
+          v.memory = 2048
+        end
+    end
+
+    config.vm.define "lovelace" do |lovelace|
+        lovelace.vm.hostname = "lovelace"
+        lovelace.vm.network "private_network", ip: "192.168.56.3",
+            virtualbox__intnet: true
+        lovelace.vm.synced_folder '.', '/vagrant', disabled: true
+
+        lovelace.vm.provider "virtualbox" do |v|
+          v.name = "pydis_lovelace"
+          v.memory = 2048
+        end
+    end
+
+    config.vm.define "neumann" do |neumann|
+        neumann.vm.hostname = "neumann"
+        neumann.vm.network "private_network", ip: "192.168.56.4",
+            virtualbox__intnet: true
+        neumann.vm.synced_folder '.', '/vagrant', disabled: true
+
+        neumann.vm.provider "virtualbox" do |v|
+          v.name = "pydis_neumann"
+          v.memory = 2048
+        end
+    end
+
+    config.vm.define "ritchie" do |ritchie|
+        ritchie.vm.hostname = "ritchie"
+        ritchie.vm.network "private_network", ip: "192.168.56.5",
+            virtualbox__intnet: true
+        ritchie.vm.synced_folder '.', '/vagrant', disabled: true
+
+        ritchie.vm.provider "virtualbox" do |v|
+          v.name = "pydis_ritchie"
+          v.memory = 2048
+        end
+    end
+
+    config.vm.define "turing" do |turing|
+        turing.vm.hostname = "turing"
+        turing.vm.network "private_network", ip: "192.168.56.6",
+            virtualbox__intnet: true
+        turing.vm.synced_folder '.', '/vagrant', disabled: true
+
+        turing.vm.provider "virtualbox" do |v|
+          v.name = "pydis_turing"
+          v.memory = 2048
+        end
+    end
+end

--- a/local_testing/hosts.yaml
+++ b/local_testing/hosts.yaml
@@ -1,0 +1,56 @@
+all:
+  hosts:
+    hopper:
+      ansible_host: 192.168.56.2
+      ip: 192.168.56.2
+      access_ip: 192.168.56.2
+    lovelace:
+      ansible_host: 192.168.56.3
+      ip: 192.168.56.3
+      access_ip: 192.168.56.3
+    neumann:
+      ansible_host: 192.168.56.4
+      ip: 192.168.56.4
+      access_ip: 192.168.56.4
+    ritchie:
+      ansible_host: 192.168.56.5
+      ip: 192.168.56.5
+      access_ip: 192.168.56.5
+    turing:
+      ansible_host: 192.168.56.6
+      ip: 192.168.56.6
+      access_ip: 192.168.56.6
+  children:
+    kube_control_plane:
+      hosts:
+        hopper:
+        turing:
+    kube_node:
+      hosts:
+        hopper:
+        turing:
+        lovelace:
+        neumann:
+        ritchie:
+    etcd:
+      hosts:
+        hopper:
+        turing:
+        lovelace:
+    k8s_cluster:
+      children:
+        kube_control_plane:
+        kube_node:
+    calico_rr:
+      hosts: {}
+    podman:
+      hosts:
+        turing:
+        lovelace:
+        hopper:
+        ritchie:
+    nginx:
+      hosts:
+        turing:
+        ritchie:
+        neumann:

--- a/local_testing/scripts/push-keys
+++ b/local_testing/scripts/push-keys
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Intended to be used in the "control" VM to push keys to the other hosts
+
+for i in {1..6} ; do
+  ssh-keyscan 192.168.56.$i >> ~/.ssh/known_hosts
+  sshpass -p vagrant ssh-copy-id 192.168.56.$i
+done


### PR DESCRIPTION
Add scripts and files required to create Virtual Machines via Vagrant (VirtualBox provider) to test the ansible deployment. Instructions can be found [in the README.md](https://github.com/python-discord/infra/blob/fd2a1a7d8959a50b2b3670278e9f300cbcbfbde3/local_testing/README.md)

---
## Ansible
![image](https://user-images.githubusercontent.com/57012020/218267053-c370257e-2607-49d6-8c44-0a9000692e2b.png)

## Kubespray Ansible
![image](https://user-images.githubusercontent.com/57012020/218267043-472c089b-f077-4a2c-bfa7-65c95f0770e6.png)

## Kubectl after Kubespray
![image](https://user-images.githubusercontent.com/57012020/218267038-621f82e9-d73d-49f7-8fa4-2f2049083a35.png)

---

# Notes

Tested on Linux by @GDWR
Tested on Windows by @shenanigansd
Not tested on MacOS

There are a few issues with our roles spotted during doing this. They are noted (not fixed) below.

1. comment out [this](https://github.com/python-discord/infra/blob/1295dd8f97b7aed56cfa842da7d1923af1a526d5/playbook.yml#L9-L12)
2. comment out [this](https://github.com/python-discord/infra/blob/761a8e124e84a82bd2272228cbff2a1260456f51/roles/ufw/tasks/main.yml#L24-L31)
3. alter [this](https://github.com/python-discord/infra/blob/d2cb45df24b42dcdebe749680ee3603a2db351b2/roles/ufw/vars/main.yml#L1-L6) to 
```yaml
rules:
  - comment: Allow internal traffic
    interface: eth1
    direction: in
    rule: allow
    from_ip: 192.168.56.0/24
```