### PR TITLE
Match casing of task handlers

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -21,7 +21,7 @@
     line: "PasswordAuthentication no"
     state: present
   notify:
-    - restart ssh
+    - Restart ssh
   tags:
     - role::common
 
@@ -33,7 +33,7 @@
     owner: root
     group: root
   notify:
-    - restart systemd-timesyncd
+    - Restart systemd-timesyncd
   tags:
     - role::common
 

--- a/roles/fail2ban/tasks/main.yml
+++ b/roles/fail2ban/tasks/main.yml
@@ -16,7 +16,7 @@
   tags:
     - role::fail2ban
   notify:
-    - reload fail2ban
+    - Reload fail2ban
 
 - name: Enable fail2ban service
   service:

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -16,7 +16,7 @@
   when:
     - prometheus_cmdline_options is defined
   notify:
-    - restart the prometheus service
+    - Restart the prometheus service
 
 - name: Configure prometheus
   copy:
@@ -30,4 +30,4 @@
   tags:
     - role::prometheus
   notify:
-    - reload the prometheus service
+    - Reload the prometheus service


### PR DESCRIPTION
Ansible is case-sensitive when specifying a handler