### PR TITLE
Make Kubernetes user creation script Linux friendly

### DIFF
--- a/kubernetes/scripts/create_x509_user_config.py
+++ b/kubernetes/scripts/create_x509_user_config.py
@@ -40,7 +40,8 @@ ROLE_BINDING_PATCH_TEMPLATE = """[
 def run_and_return_output(command: str, cwd: str | None = None) -> str:
     """Run a command in a shell and return the result as a string."""
     return subprocess.run(
-        command,  # noqa: S603
+        command,
+        shell=True,  # noqa: S602
         stdout=subprocess.PIPE,
         text=True,
         check=True,
@@ -84,7 +85,7 @@ def give_user_perms(tmpdir: str) -> None:
 
 def build_kubectl_config(tmpdir: str) -> None:
     """Build up a kubectl config from all the files in the tmpdir."""
-    cluster_public_key = run_and_return_output(r"kubectl get cm kube-root-ca.crt -o jsonpath={['data']['ca\.crt']}")
+    cluster_public_key = run_and_return_output(r"kubectl get cm kube-root-ca.crt -o jsonpath={.data.ca\.crt}")
     with Path(tmpdir, "ca.crt").open("w") as f:
         f.write(cluster_public_key)
     cluster_url = run_and_return_output("kubectl config view --minify --output jsonpath={.clusters[*].cluster.server}")


### PR DESCRIPTION
Set `shell=True` to make the user generation script work on POSIX systems.

Additionally, change some quoting when fetching the Kubernetes CA to be POSIX friendly.

This needs to be tested on Windows to ensure the backwards compatibility is not affected. Due to the nature of how RBAC works, this is safe to run on your existing user account and will not remove any of your accesses/invalidate your tokens if you do want to test it.