### PR TITLE
Block HEAD requests to Pinnwand

### DIFF
--- a/kubernetes/namespaces/default/pinnwand/ingress.yaml
+++ b/kubernetes/namespaces/default/pinnwand/ingress.yaml
@@ -5,6 +5,11 @@ metadata:
     nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
     nginx.ingress.kubernetes.io/auth-tls-secret: "kube-system/mtls-client-crt-bundle"
     nginx.ingress.kubernetes.io/auth-tls-error-page: "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    # block HEAD requests
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($request_method = HEAD) {
+        return 444;
+      }
   name: pinnwand
 spec:
   tls:

--- a/kubernetes/namespaces/monitoring/alerts/alerts.d/nginx.yaml
+++ b/kubernetes/namespaces/monitoring/alerts/alerts.d/nginx.yaml
@@ -3,7 +3,7 @@ groups:
   rules:
 
   - alert: NGINX4XXRequests
-    expr: sum by(service) (rate(nginx_ingress_controller_requests{status=~"^4..", status!="404", service!="pixels"}[1m])) / sum by(service) (rate(nginx_ingress_controller_requests[1m])) > 0.5
+    expr: sum by (service) (rate(nginx_ingress_controller_requests{service!="pixels",status!~"404|444",status=~"^4.."}[1m])) / sum by (service) (rate(nginx_ingress_controller_requests[1m])) > 0.5
     for: 1m
     labels:
       severity: page


### PR DESCRIPTION
- **Return HTTP 444 on HEAD requests to pinnwand**
- **Exclude HTTP 444 from 4XX alerts as it is manually sent**

We were having a lot of HEAD requests sent to Pinnwand that would result in 405s and trip our monitoring.

This PR blocks those requests, they would have been erroring responses anyway so this PR just stops them from triggering our monitoring.
