### PR TITLE
Remove custom postgres-exporter queries

### DIFF
--- a/kubernetes/namespaces/monitoring/exporters/postgres/postgres_exporter.yaml
+++ b/kubernetes/namespaces/monitoring/exporters/postgres/postgres_exporter.yaml
@@ -27,26 +27,15 @@ spec:
               memory: 50Mi
           ports:
             - containerPort: 9187
-          env:
-            - name: PG_EXPORTER_EXTEND_QUERY_PATH
-              value: /opt/python-discord/queries/queries.yaml
           envFrom:
             - secretRef:
                 name: postgres-exporter-env
           securityContext:
             readOnlyRootFilesystem: true
-          volumeMounts:
-          - mountPath: /opt/python-discord/queries
-            name: queries
       securityContext:
         fsGroup: 2000
         runAsUser: 1000
         runAsNonRoot: true
-      volumes:
-      - configMap:
-          defaultMode: 420
-          name: postgres-exporter-queries
-        name: queries
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
These feature has been deprecated by postgres-exporter, and the only query currently defined in our file didn't work anyway.