### PR TITLE
Remove bashrc copy task

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -78,6 +78,7 @@
   copy:
     src: /etc/skel/.bashrc
     dest: /root/.bashrc
+    remote_src: true
     mode: '0644'
     owner: root
     group: root


### PR DESCRIPTION
This was copying from the local machine and as such was not deterministic. In addition, we will use user accounts for login instead of root going forward, so everyone can customize their own bashrc as they see fit.