### PR TITLE
Configure SSH daemon options in unit dropin

### DIFF
--- a/ansible/roles/common/handlers/main.yml
+++ b/ansible/roles/common/handlers/main.yml
@@ -1,9 +1,13 @@
-- name: Restart ssh
+- name: Reload ssh
   service:
     name: ssh
-    state: restarted
+    state: reloaded
+  tags:
+    - role::common
 
 - name: Restart systemd-timesyncd
   service:
     name: systemd-timesyncd
     state: restarted
+  tags:
+    - role::common

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -14,14 +14,21 @@
   tags:
     - role::common
 
-- name: Disable SSH password authentication
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    regexp: "^PasswordAuthentication"
-    line: "PasswordAuthentication no"
-    state: present
+- name: Configure SSH daemon options
+  ansible.builtin.copy:
+    content: |
+      # Ansible managed
+
+      PasswordAuthentication no
+      PermitRootLogin no
+      ClientAliveInterval 300
+      ClientAliveCountMax 3
+    dest: /etc/ssh/sshd_config.d/pydis.conf
+    owner: root
+    group: root
+    mode: "0444"
   notify:
-    - Restart ssh
+    - Reload ssh
   tags:
     - role::common
 


### PR DESCRIPTION
Disable password authentication and root logins and use a configuration file that is independent of the `sshd_config` that `apt` itself will modify on upgrades.