### PR TITLE
Do not use vault token for linting branches

### DIFF
--- a/.github/workflows/lint-ansible.yaml
+++ b/.github/workflows/lint-ansible.yaml
@@ -2,9 +2,6 @@ name: Lint Ansible play books
 
 on:
   workflow_call:
-    secrets:
-      vault-password:
-        required: true
 
 jobs:
   lint-ansible:
@@ -21,7 +18,7 @@ jobs:
       - name: Run ansible lint
         run: |
           cd ansible
-          echo "$VAULT_PASSWORD" > vault_passwords
+          # Remove any Vaulted files and Vault configuration
+          grep -R '$ANSIBLE_VAULT;' --files-with-matches . | xargs rm
+          sed --in-place '/vault_password_file/d' ansible.cfg
           ansible-lint --offline
-        env:
-          VAULT_PASSWORD: "${{ secrets.vault-password }}"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,7 +1,7 @@
 name: Lint files using pre-commit
 
 on:
-  workflow_call
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,8 +37,6 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.ansible == 'true' }}
     uses: ./.github/workflows/lint-ansible.yaml
-    secrets:
-      vault-password: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
 
   lint-kubernetes:
     needs: changes


### PR DESCRIPTION
Prevent security problems from exposing the vault token on non-main
branches.
