### PR TITLE
Use nftables for firewalling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "hugodocs/themes/hugo-book"]
 	path = docs/themes/hugo-book
 	url = https://github.com/alex-shpak/hugo-book
+[submodule "ansible/roles/nftables"]
+	path = ansible/roles/nftables
+	url = git@github.com:jchristgit/ansible-role-nftables.git

--- a/ansible/group_vars/all/nftables.yml
+++ b/ansible/group_vars/all/nftables.yml
@@ -1,0 +1,69 @@
+---
+nftables_configuration: |
+  flush ruleset
+
+  table inet firewall {
+    set tcp_accepted {
+      type inet_service
+      elements = {
+        # OpenSSH
+        ssh,
+        # NGINX
+        http,
+        https
+      }
+    }
+
+    chain input {
+      type filter hook input priority 0
+
+      # Drop anything not explicitly dropped or accepted by default
+      policy drop
+
+      # Drop invalid packets
+      ct state invalid drop
+
+      # Allow already established connections
+      ct state established,related accept
+
+      # Allow loopback
+      iif lo accept
+
+      # Allow certain inbound ICMP types (ping, traceroute).
+      # With these allowed you are a good network citizen.
+      meta l4proto { icmp, ipv6-icmp } counter accept
+
+      # Standard allowed ports
+      iifname {{ ansible_default_ipv4.interface }} tcp dport @tcp_accepted ct state new accept
+  {% if ansible_default_ipv4.interface != ansible_default_ipv6.interface %}
+      iifname {{ ansible_default_ipv6.interface }} tcp dport @tcp_accepted ct state new accept
+  {% endif %}
+
+      # WireGuard client connections
+      iifname {{ ansible_default_ipv4.interface }} udp dport {{ wireguard_port }} ct state new accept
+  {% if ansible_default_ipv4.interface != ansible_default_ipv6.interface %}
+      iifname {{ ansible_default_ipv6.interface }} udp dport {{ wireguard_port }} ct state new accept
+  {% endif %}
+
+    }
+
+    chain forward {
+      type filter hook forward priority 0
+      policy drop
+      ct state invalid drop
+      ct state established,related accept
+
+      iifname wg0 ip daddr 10.0.0.0/8 accept
+    }
+
+    chain output {
+      type filter hook output priority 0
+      policy accept
+
+      ip6 nexthdr ipv6-icmp accept
+    }
+
+    chain postrouting {
+      type nat hook postrouting priority 100;
+    }
+  }

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -3,7 +3,8 @@
   roles:
     - common
     - pydis-users
-    - ufw
+    - ufw  # can be removed
+    - nftables
     - prometheus-node-exporter
     - wireguard
     - fail2ban

--- a/ansible/roles/ufw/tasks/main.yml
+++ b/ansible/roles/ufw/tasks/main.yml
@@ -1,37 +1,17 @@
-- name: Install UFW
+- name: Disable UFW  # noqa
+  community.general.ufw:
+    state: disabled
+  tags:
+    - role::ufw
+  ignore_errors: true  # subsequent deploys
+
+- name: Uninstall UFW
   apt:
-    update_cache: true
-    cache_valid_time: 3600
-    pkg:
-      - ufw
-  tags:
-    - role::ufw
+    name: ufw
+    state: absent
+    purge: true
 
-- name: Allow OpenSSH
-  community.general.ufw:
-    rule: allow
-    name: OpenSSH
-  tags:
-    - role::ufw
-
-- name: Enable UFW and deny all traffic by default
-  community.general.ufw:
-    state: enabled
-    policy: deny
-  tags:
-    - role::ufw
-
-- name: Allow WireGuard
-  community.general.ufw:
-    rule: allow
-    proto: udp
-    port: "{{ wireguard_port }}"
-    comment: "Allow WireGuard"
-  tags:
-    - role::ufw
-
-- name: Apply service-specific rules
-  community.general.ufw: "{{ item }}"
-  with_items: "{{ ufw_rules }}"
-  tags:
-    - role::ufw
+- name: Purge UFW files
+  file:
+    path: /etc/ufw
+    state: absent

--- a/ansible/roles/ufw/vars/main.yml
+++ b/ansible/roles/ufw/vars/main.yml
@@ -1,6 +1,0 @@
-ufw_rules:
-  - comment: Allow internal traffic
-    interface: wg0
-    direction: in
-    rule: allow
-    from_ip: 10.0.0.0/8


### PR DESCRIPTION
nftables is the modern replacement for iptables, which ufw uses under
the hood. It allows us to specify firewall rules in a simple text file
(with as much or as little abstraction as we want) and is quick to
update and read. The text-file format allows more liberty with
commenting compared to UFW. The existing `ufw` role has been converted
to simply remove UFW. This has already been deployed on lovelace.
