### PR TITLE
Add a couple of enhancements to the local testing guide.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv
 .vscode/
 *.config
 .env
+.idea

--- a/ansible/.gitattributes
+++ b/ansible/.gitattributes
@@ -1,1 +1,2 @@
+* text=auto
 roles/pydis-users/vars/main.yml diff=ansible-vault merge=binary

--- a/ansible/local_testing/README.md
+++ b/ansible/local_testing/README.md
@@ -1,27 +1,51 @@
 # Testing Locally
 
+This section contains the necessary steps in order to be able to setup virtual machines that mimic our netcup servers and be able to run the ansible roles/playbooks we have on them.
+
 ### Requirements
 
 - [Vagrant](https://developer.hashicorp.com/vagrant/docs/installation)
 - [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 
-## Get Started
 
-```shell
-vagrant up                  # This will take a while
-vagrant ssh                 # Get a shell, password=vagrant
+### Getting started
 
-# inside control VM
-/vagrant/scripts/push-keys  # Push the control VM's ssh key to all nodes
+1. Creating the virtual boxes
 
-# run ansible
-cd infra
-# if you're on Windows, the `infra` directory will be mounted with permissions set to 777
-# which ansible will reject as insecure
-# export the below environment variable to force anisble to accept the writable config
-# export ANSIBLE_CONFIG='/home/vagrant/infra/ansible.cfg'
+On your host machine, run the following:
+
+```bash
+cd ansible/local_testing
+vagrant up
+```
+
+This will create all the virtual boxes on which we will run our ansible playbooks.
+
+2. Push the control VM's ssh key to all nodes
+
+
+```bash
+vagrant ssh  # This will give you terminal access to the `control` VM, which we will use as the ansible control node.
+
+cd /home/vagrant/infra
+bash ./ansible/local_testing/scripts/push-keys
+```
+
+> If you're on windows, you might run into line ending issues when running the `push-keys` script.
+> To fix it, run this **while still inside the ssh session*: `sed -i 's/\r$//' /home/vagrant/infra/ansible/local_testing/scripts/push-keys`
+
+
+3. Run the ansible setup playbook
+
+```bash
+cd /home/vagrant/infra/ansible
 ansible-playbook playbook.yml --inventory local_testing/hosts.yaml --user vagrant
 ```
+
+> This will prompt you for the sudo password, whose value is `vagrant`.
+
+
+### Virtual machine IPs
 
 Below are the IPs of the VMs on the VirtualBox network
 ```yaml
@@ -37,12 +61,25 @@ vms:
 
 # Fixes/Notes
 
+
+### Ansible cannot decrypt the files encrypted with ansible vault.
+
+* The `ansible/roles/certbot/vars/main.yaml` and `ansible/roles/pydis-users/vars/main.yaml` files have been encrypted with ansible vault due to their sensitive content.
+
+* If you lack access to the vault, you're going to have to either define your own variables or exclude the appropriate roles.
+
+* If you do have access to the vault, make sure that your `vault_passwords` file has been synced to the vagrant control VM.
+
+
 ### There was an error when attempting to rsync a synced folder.
 
 ```shell
 vagrant plugin install vagrant-vbguest
 ```
 
+### Some files are not synced from the host machine to the control VM
+
+Try forcing the sync by running this command `vagrant rsync-auto`
 
 ### Kernel module is not loaded
 ```shell

--- a/ansible/local_testing/Vagrantfile
+++ b/ansible/local_testing/Vagrantfile
@@ -2,10 +2,9 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-    config.vm.box = "bento/debian-11"
-    config.vm.box_version = "202212.11.0"
+    config.vm.box = "bento/debian-12"
     config.vm.provision "shell", inline: <<-SHELL
-        apt-get update
+        sudo apt-get update
         apt-get install -y python3 openssh-server
         systemctl enable ssh
     SHELL
@@ -14,7 +13,7 @@ Vagrant.configure("2") do |config|
         control.vm.hostname = "control"
         control.vm.network "private_network", ip: "192.168.56.1",
             virtualbox__intnet: true
-        control.vm.synced_folder "../", "/home/vagrant/infra"
+        control.vm.synced_folder "../", "/home/vagrant/infra", type: "rsync"
         control.vm.provision "shell", inline: <<-SHELL
             apt-get install -y sshpass python3-pip
         SHELL

--- a/ansible/local_testing/Vagrantfile
+++ b/ansible/local_testing/Vagrantfile
@@ -5,22 +5,27 @@ Vagrant.configure("2") do |config|
     config.vm.box = "bento/debian-12"
     config.vm.provision "shell", inline: <<-SHELL
         sudo apt-get update
-        apt-get install -y python3 openssh-server
+        apt-get install -y python3 openssh-server sshpass
         systemctl enable ssh
     SHELL
 
     config.vm.define "control", primary: true do |control|
         control.vm.hostname = "control"
-        control.vm.network "private_network", ip: "192.168.56.1",
-            virtualbox__intnet: true
-        control.vm.synced_folder "../", "/home/vagrant/infra", type: "rsync"
-        control.vm.provision "shell", inline: <<-SHELL
-            apt-get install -y sshpass python3-pip
+        control.vm.network "private_network", ip: "192.168.56.1", virtualbox__intnet: true
+        control.vm.synced_folder "../..", "/home/vagrant/infra", type: "rsync", rsync__exclude: ['.git-crypt', '.ruff_cache', 'dns', 'docs', 'kubernetes', 'venv', '.gitattributes', '.git', '.gitmodules', '.gitignore', '.pre-commit-config.yaml', 'LICENSE', 'README.md', 'server_bootstrap.sh']
+
+        control.vm.provision "Install poetry", type: "shell", inline: <<-SHELL
+            apt-get install -y python3-poetry
         SHELL
 
-        control.vm.provision "shell", privileged: false, inline: <<-SHELL
-            python3 -m pip install --user ansible dnspython
+        control.vm.provision "Generate ssh keys", type: "shell", privileged: false, inline: <<-SHELL
             ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa <<< y
+        SHELL
+
+        control.vm.provision "Install dependencies", type: "shell", privileged: false, inline: <<-SHELL
+            cd /home/vagrant/infra
+            sudo poetry config virtualenvs.create false
+            sudo PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring poetry install --only ansible --no-root
         SHELL
 
         control.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
This does the following:
* Update debian box version used
* Add the missing ansible installation during the provisioning of VMs
* Fix the wrong synced folder paths in the docs
* Add more fixes/notes on what could go wrong
* Make the readme richer by setting up execution contexts/info