### PR TITLE
Harden SSH security and prevent some misconfigurations

### DIFF
--- a/ansible/roles/common/handlers/main.yml
+++ b/ansible/roles/common/handlers/main.yml
@@ -1,10 +1,4 @@
-- name: Reload ssh
-  service:
-    name: ssh
-    state: reloaded
-  tags:
-    - role::common
-
+---
 - name: Restart systemd-timesyncd
   service:
     name: systemd-timesyncd

--- a/ansible/roles/common/meta/main.yml
+++ b/ansible/roles/common/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - ssh

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -14,16 +14,31 @@
   tags:
     - role::common
 
+# Temporary cleanup task. Can be removed later.
+- name: Remove old SSH daemon options file
+  ansible.builtin.file:
+    path: /etc/ssh/sshd_config.d/pydis.conf
+    state: absent
+  tags:
+    - role::common
+
 - name: Configure SSH daemon options
   ansible.builtin.copy:
     content: |
       # Ansible managed
 
+      # Logins
       PasswordAuthentication no
       PermitRootLogin no
+
+      # Forwarding
+      AllowAgentForwarding no
+      X11Forwarding no
+
+      # Connection keepalive
       ClientAliveInterval 300
       ClientAliveCountMax 3
-    dest: /etc/ssh/sshd_config.d/pydis.conf
+    dest: /etc/ssh/sshd_config.d/hardening.conf
     owner: root
     group: root
     mode: "0444"

--- a/ansible/roles/pydis-users/meta/main.yml
+++ b/ansible/roles/pydis-users/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - ssh

--- a/ansible/roles/pydis-users/tasks/main.yml
+++ b/ansible/roles/pydis-users/tasks/main.yml
@@ -25,3 +25,18 @@
   loop: "{{ pydis_users__users | dict2items }}"
   tags:
     - role::pydis-users
+
+- name: Allow SSH logins for pydis users
+  ansible.builtin.copy:
+    content: |
+      # Ansible managed
+
+      AllowUsers {{ pydis_users__users | sort | join(' ') }}
+    dest: /etc/ssh/sshd_config.d/pydis-users-login.conf
+    owner: root
+    group: root
+    mode: "0444"
+  notify:
+    - Reload ssh
+  tags:
+    - role::pydis-users

--- a/ansible/roles/ssh/handlers/main.yml
+++ b/ansible/roles/ssh/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Reload ssh
+  service:
+    name: ssh
+    state: reloaded
+  tags:
+    - role::ssh


### PR DESCRIPTION
Disable agent forwarding and X11 forwarding in the default
configuration. Users can still forward this if they really want to by
installing a custom forwarder and utilizing their shell access to spawn
it, but with this, we're making it impossible for people to accidentally
forward their agent or their X socket to the remote server.

Additionally, change the SSH configuration such that only the Python
Discord users are allowed to log in.
