### PR TITLE
Configure default security limits

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -47,6 +47,21 @@
   tags:
     - role::common
 
+- name: Configure default security limits
+  ansible.builtin.copy:
+    content: |
+      # Ansible managed
+
+      # <domain>  <type>  <item>  <value>
+      *           soft    nproc   100
+      *           hard    nproc   200
+    dest: /etc/security/limits.d/pydis.conf
+    owner: root
+    group: root
+    mode: "0444"
+  tags:
+    - role::common
+
 - name: Set timezone to UTC
   file:
     src: /usr/share/zoneinfo/Etc/UTC


### PR DESCRIPTION
The new limits allow each user to run a maximum of 100 processes by
default, allowing to manually raise this number to 200.

When a custom "pydis" group or similar is introduced, I plan to expand
this to also specify other limits to prevent user error from causing
problems on the system.
