### PR TITLE
Set the sshd backend for fail2ban

### DIFF
--- a/ansible/roles/fail2ban/files/jail.local
+++ b/ansible/roles/fail2ban/files/jail.local
@@ -6,3 +6,4 @@ findtime = 2h
 
 [sshd]
 mode = aggressive
+backend=systemd


### PR DESCRIPTION
Fail2ban has been failing to start on lovelace for a while.

It was erroring out with `Failed during configuration: Have not found any log file for sshd jail`

According to this [issue](https://github.com/fail2ban/fail2ban/issues/3567) which redirects to [this](https://github.com/fail2ban/fail2ban/issues/3292#issuecomment-1142503461) comment, setting the backend to systemd fixes it.

Deployed and tested on lovelace