### PR TITLE
Perform fail2ban bans directly via nftables

### DIFF
--- a/ansible/roles/fail2ban/files/jail.local
+++ b/ansible/roles/fail2ban/files/jail.local
@@ -3,6 +3,8 @@ ignoreip = 127.0.0.1/8 ::1 192.168.1.0/24 10.0.0.0/8
 bantime = 24h
 maxretry = 3
 findtime = 2h
+banaction = nftables
+banaction_allports = nftables[type=allports]
 
 [sshd]
 mode = aggressive


### PR DESCRIPTION
See upstream at
https://github.com/fail2ban/fail2ban/commit/d0d07285234871bad3dc0c359d0ec03365b6dddc,
this will be incorporated into Debian at the next release.
