### PR TITLE
Configure Prometheus alerting for failed systemd units

### DIFF
--- a/ansible/host_vars/lovelace/prometheus.yml
+++ b/ansible/host_vars/lovelace/prometheus.yml
@@ -73,3 +73,18 @@ prometheus_configuration:
         - source_labels: [__param_target]
           target_label: instance
         - target_label: __address__
+
+prometheus_rules: |
+  {% raw %}
+  groups:
+    - name: node
+      rules:
+        - alert: node/systemd-unit-failed
+          # expr: node_systemd_unit_state{state="failed", name!="openipmi.service", name!="nvmf-autoconnect.service"} != 0
+          expr: node_systemd_unit_state{state="failed"} != 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: Node systemd unit {{ $labels.name }} has failed (instance {{ $labels.instance }})
+  {% endraw %}

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -37,7 +37,7 @@
   copy:
     content: |
       # Ansible managed
-      {{ prometheus_rules | to_nice_yaml }}
+      {{ prometheus_rules }}
     dest: /etc/prometheus/rules.yml
     owner: prometheus
     group: prometheus


### PR DESCRIPTION
The two services that I would normally exclude are intentionally not
excluded right now to test out the alertmanager setup. If all goes well,
we should receive a notification on Discord.
