### PR TITLE
Add secret reflector

### DIFF
--- a/kubernetes/namespaces/cert-manager/cert-manager/certificates/pythondiscord.com.yaml
+++ b/kubernetes/namespaces/cert-manager/cert-manager/certificates/pythondiscord.com.yaml
@@ -10,3 +10,9 @@ spec:
   issuerRef:
     name: letsencrypt
     kind: ClusterIssuer
+  secretTemplate:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "apis,forms,modmail,monitoring,pixels,prestashop,tooling,web"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "apis,forms,modmail,monitoring,pixels,prestashop,tooling,web"

--- a/kubernetes/namespaces/kube-system/reflector/README.md
+++ b/kubernetes/namespaces/kube-system/reflector/README.md
@@ -1,0 +1,11 @@
+# Kubernetes reflector
+
+We use [kubernetes-reflector](github.com/emberstack/kubernetes-reflector) to mirror certificate resources into all namespaces that need access to the wildcard certificates used for the cluster.
+
+It is deployed using Helm with no additional configuration using the following steps:
+
+``` sh
+$ helm repo add emberstack https://emberstack.github.io/helm-charts
+$ helm repo update
+$ helm upgrade -n kube-system --install reflector emberstack/reflector
+```


### PR DESCRIPTION
Add a deployment of [kubernetes-reflector](https://github.com/emberstack/kubernetes-reflector) to copy wildcard certs into all namespaces that need access to the TLS certificates.