### PR TITLE
Migrate to pydis.wtf for internal tooling

### DIFF
--- a/ansible/host_vars/lovelace/prometheus.yml
+++ b/ansible/host_vars/lovelace/prometheus.yml
@@ -11,7 +11,7 @@ prometheus_configuration:
       - scheme: https
         static_configs:
           - targets:
-              - alertmanager.pythondiscord.com
+              - alertmanager.pydis.wtf
 
   rule_files:
     - rules.yml

--- a/dns/zones/pythondiscord.com.yaml
+++ b/dns/zones/pythondiscord.com.yaml
@@ -192,14 +192,6 @@ pixels:
   type: A
   value: 194.195.247.228
 
-pixels-modsite:
-  octodns:
-    cloudflare:
-      proxied: true
-  ttl: 300
-  type: A
-  value: 194.195.247.228
-
 policy-bot:
   octodns:
     cloudflare:

--- a/docs/content/docs/onboarding/tools.md
+++ b/docs/content/docs/onboarding/tools.md
@@ -43,7 +43,7 @@ dev-ops team.
 ## [Prometheus Dashboard](https://prometheus.pydis.wtf/) (☁️))
 
 This provides access to the Prometheus query console. You may also enjoy the
-[Alertmanager Console](https://alertmanager.pythondiscord.com/).
+[Alertmanager Console](https://alertmanager.pydis.wtf/).
 
 ## [King Arthur](https://github.com/python-discord/king-arthur/)
 

--- a/docs/content/docs/onboarding/tools.md
+++ b/docs/content/docs/onboarding/tools.md
@@ -40,7 +40,7 @@ listed below:
 Accessed via a GitHub login, with permission for anyone in the dev-core or
 dev-ops team.
 
-## [Prometheus Dashboard](https://prometheus.pythondiscord.com/) (☁️))
+## [Prometheus Dashboard](https://prometheus.pydis.wtf/) (☁️))
 
 This provides access to the Prometheus query console. You may also enjoy the
 [Alertmanager Console](https://alertmanager.pythondiscord.com/).

--- a/kubernetes/namespaces/cert-manager/cert-manager/certificates/pydis.wtf.yaml
+++ b/kubernetes/namespaces/cert-manager/cert-manager/certificates/pydis.wtf.yaml
@@ -13,6 +13,6 @@ spec:
   secretTemplate:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "monitoring,modmail,tooling"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "monitoring,modmail,tooling,pixels"
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "monitoring,modmail,tooling"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "monitoring,modmail,tooling,pixels"

--- a/kubernetes/namespaces/cert-manager/cert-manager/certificates/pydis.wtf.yaml
+++ b/kubernetes/namespaces/cert-manager/cert-manager/certificates/pydis.wtf.yaml
@@ -13,6 +13,6 @@ spec:
   secretTemplate:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "monitoring,modmail"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "monitoring,modmail,tooling"
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "monitoring,modmail"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "monitoring,modmail,tooling"

--- a/kubernetes/namespaces/monitoring/alerts/alertmanager/deployment.yaml
+++ b/kubernetes/namespaces/monitoring/alerts/alertmanager/deployment.yaml
@@ -52,7 +52,7 @@ spec:
           - |
             exec /bin/alertmanager \
               --config.file=/opt/pydis/alertmanager/config.d/alertmanager.yaml \
-              --web.external-url=https://alertmanager.pythondiscord.com \
+              --web.external-url=https://alertmanager.pydis.wtf \
               --storage.path=/data/alertmanager \
               $(cat /tmp/peers)
         ports:

--- a/kubernetes/namespaces/monitoring/alerts/alertmanager/ingress.yaml
+++ b/kubernetes/namespaces/monitoring/alerts/alertmanager/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-tls-error-page: "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "AlertManager_LB"
-    nginx.ingress.kubernetes.io/session-cookie-domain: "alertmanager.pythondiscord.com"
+    nginx.ingress.kubernetes.io/session-cookie-domain: "alertmanager.pydis.wtf"
     nginx.ingress.kubernetes.io/session-cookie-samesite: "Strict"
     nginx.ingress.kubernetes.io/session-cookie-expires: "3600"
   name: alertmanager
@@ -15,9 +15,10 @@ metadata:
 spec:
   tls:
   - hosts:
-      - "*.pythondiscord.com"
+      - "*.pydis.wtf"
+    secretName: pydis.wtf-tls
   rules:
-  - host: alertmanager.pythondiscord.com
+  - host: alertmanager.pydis.wtf
     http:
       paths:
       - path: /

--- a/kubernetes/namespaces/monitoring/prometheus/deployment.yaml
+++ b/kubernetes/namespaces/monitoring/prometheus/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         args: [
           "--storage.tsdb.path", "/opt/prometheus/data",
           "--config.file", "/etc/prometheus/prometheus.yaml",
-          "--web.external-url", "https://prometheus.pythondiscord.com",
+          "--web.external-url", "https://prometheus.pydis.wtf",
           "--web.enable-lifecycle",
           "--web.enable-admin-api",
           "--web.page-title", "Python Discord Prometheus",

--- a/kubernetes/namespaces/monitoring/prometheus/ingress.yaml
+++ b/kubernetes/namespaces/monitoring/prometheus/ingress.yaml
@@ -10,9 +10,10 @@ metadata:
 spec:
   tls:
   - hosts:
-      - "*.pythondiscord.com"
+      - "*.pydis.wtf"
+    secretName: pydis.wtf-tls
   rules:
-  - host: prometheus.pythondiscord.com
+  - host: prometheus.pydis.wtf
     http:
       paths:
       - path: /

--- a/kubernetes/namespaces/pixels/pixels-modsite/README.md
+++ b/kubernetes/namespaces/pixels/pixels-modsite/README.md
@@ -1,6 +1,6 @@
 # Pixels
 
-The deployment for the [Pixels modsite project](https://git.pydis.com/pixels-modsite), hosted at https://pixels-modsite.pythondiscord.com.
+The deployment for the [Pixels modsite project](https://git.pydis.com/pixels-modsite), hosted at https://pixels-mod.pydis.wtf.
 
 This mod site will give Discord mods easy access to moderation actions for the pixels event.
 

--- a/kubernetes/namespaces/pixels/pixels-modsite/ingress.yaml
+++ b/kubernetes/namespaces/pixels/pixels-modsite/ingress.yaml
@@ -10,10 +10,10 @@ metadata:
 spec:
   tls:
   - hosts:
-      - "*.pythondiscord.com"
-    secretName: pythondiscord.com-tls
+      - "*.pydis.wtf"
+    secretName: pydis.wtf-tls
   rules:
-  - host: pixels-modsite.pythondiscord.com
+  - host: pixels-mod.pydis.wtf
     http:
       paths:
       - path: /

--- a/kubernetes/namespaces/tooling/bitwarden/README.md
+++ b/kubernetes/namespaces/tooling/bitwarden/README.md
@@ -1,6 +1,6 @@
 # BitWarden
 
-Our internal password manager, used by the admins to share passwords for our services. Hosted at https://bitwarden.pythondiscord.com
+Our internal password manager, used by the admins to share passwords for our services. Hosted at https://bitwarden.pydis.wtf
 
 To deploy this, first set up the secrets (see below) and then run `kubectl apply -f .` in this folder.
 

--- a/kubernetes/namespaces/tooling/bitwarden/configmap.yaml
+++ b/kubernetes/namespaces/tooling/bitwarden/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: tooling
 data:
   # Domain to access bitwarden by
-  DOMAIN: "https://bitwarden.pythondiscord.com"
+  DOMAIN: "https://bitwarden.pydis.wtf"
 
   # Password hint must be sent to an email when this is false.
   # When it's true, it'll be shown right on the page.

--- a/kubernetes/namespaces/tooling/bitwarden/ingress.yaml
+++ b/kubernetes/namespaces/tooling/bitwarden/ingress.yaml
@@ -10,10 +10,10 @@ metadata:
 spec:
   tls:
   - hosts:
-      - "*.pythondiscord.com"
-    secretName: pythondiscord.com-tls
+      - "*.pydis.wtf"
+    secretName: pydis.wtf-tls
   rules:
-  - host: bitwarden.pythondiscord.com
+  - host: bitwarden.pydis.wtf
     http:
       paths:
       - path: /

--- a/kubernetes/namespaces/tooling/metabase/ingress.yaml
+++ b/kubernetes/namespaces/tooling/metabase/ingress.yaml
@@ -10,10 +10,10 @@ metadata:
 spec:
   tls:
   - hosts:
-      - "*.pythondiscord.com"
-    secretName: pythondiscord.com-tls
+      - "*.pydis.wtf"
+    secretName: pydis.wtf-tls
   rules:
-  - host: metabase.pythondiscord.com
+  - host: metabase.pydis.wtf
     http:
       paths:
       - path: /

--- a/kubernetes/namespaces/tooling/policy-bot/README.md
+++ b/kubernetes/namespaces/tooling/policy-bot/README.md
@@ -5,7 +5,7 @@ Actual review policy is stored inside our GitHub repositories in the `.github/re
 
 ## GitHub Configuration
 
-Follow the instructions in the [repository](https://github.com/palantir/policy-bot#deployment) to provision a GitHub application. Our manifests are configured to run the policy bot at https://policy-bot.pythondiscord.com/.
+Follow the instructions in the [repository](https://github.com/palantir/policy-bot#deployment) to provision a GitHub application. Our manifests are configured to run the policy bot at https://policy-bot.pydis.wtf/.
 
 ## Secrets
 
@@ -21,4 +21,4 @@ This app requires a `policy-bot-defaults` secret with the following entries:
 
 Run `kubectl apply -f .` inside this directory to apply the the configuration.
 
-Access the running application over [policy-bot.pythondiscord.com]([https://policy-bot.pythondiscord.com/])!
+Access the running application over [policy-bot.pydis.wtf]([https://policy-bot.pydis.wtf/])!

--- a/kubernetes/namespaces/tooling/policy-bot/configmap.yaml
+++ b/kubernetes/namespaces/tooling/policy-bot/configmap.yaml
@@ -11,7 +11,7 @@ data:
       address: "0.0.0.0"
       port: 8080
       # The public URL, used for URL generation when the server is behind a proxy
-      public_url: https://policy-bot.pythondiscord.com/
+      public_url: https://policy-bot.pydis.wtf/
 
     # Options for logging output
     logging:

--- a/kubernetes/namespaces/tooling/policy-bot/ingress.yaml
+++ b/kubernetes/namespaces/tooling/policy-bot/ingress.yaml
@@ -10,10 +10,10 @@ metadata:
 spec:
   tls:
   - hosts:
-      - "*.pythondiscord.com"
-    secretName: pythondiscord.com-tls
+      - "*.pydis.wtf"
+    secretName: pydis.wtf-tls
   rules:
-  - host: policy-bot.pythondiscord.com
+  - host: policy-bot.pydis.wtf
     http:
       paths:
       - path: /


### PR DESCRIPTION
All redirects have been set up at Cloudflare, these changes are all deployed.

Closes #230.