### PR TITLE
Generate a certificate for `prometheus.lovelace.box.pydis.wtf`

### DIFF
--- a/ansible/roles/certbot/vars/main/main.yml
+++ b/ansible/roles/certbot/vars/main/main.yml
@@ -4,3 +4,4 @@ certbot_email: "joe@jb3.dev"
 certbot_domains:
   - pydis.wtf
   - pythondiscord.com
+  - prometheus.lovelace.box.pydis.wtf

--- a/dns/zones/pydis.wtf.yaml
+++ b/dns/zones/pydis.wtf.yaml
@@ -153,6 +153,20 @@ prometheus:
   type: A
   value: 194.195.247.228
 
+prometheus.lovelace.box:
+  - octodns:
+      cloudflare:
+        auto-ttl: true
+    ttl: 300
+    type: A
+    value: 89.58.26.118
+  - octodns:
+      cloudflare:
+        auto-ttl: true
+    ttl: 300
+    type: AAAA
+    value: 2a03:4000:62:ce0:2496:aeff:fe97:dea4
+
 turing.box:
   - octodns:
       cloudflare:


### PR DESCRIPTION
This will be used to allow traffic to the prometheus instance on lovelace, enabling grafana to pull metrics.