### PR TITLE
Deploy Bounca

### DIFF
--- a/dns/zones/pydis.wtf.yaml
+++ b/dns/zones/pydis.wtf.yaml
@@ -59,6 +59,14 @@ bitwarden:
   type: A
   value: 194.195.247.228
 
+bounca:
+  octodns:
+    cloudflare:
+      proxied: true
+  ttl: 300
+  type: A
+  value: 194.195.247.228
+
 cloud.native.is.fun.and.easy:
   octodns:
     cloudflare:


### PR DESCRIPTION
Deploys Bounca, a small web-based UI for management of our certificate
authorities, allowing us finer but easier control over client certificates that
we issue for things like Netcup <-> Kubernetes communication.