### PR TITLE
[ansible] File server fixes

### DIFF
--- a/ansible/roles/nginx/files/files.pydis.wtf
+++ b/ansible/roles/nginx/files/files.pydis.wtf
@@ -5,6 +5,6 @@ server {
   root        /var/www/turing;
 
   location / {
-    try_files $uri $uri/;
+    try_files $uri $uri/ =404;
   }
 }

--- a/ansible/roles/nginx/files/files.pydis.wtf
+++ b/ansible/roles/nginx/files/files.pydis.wtf
@@ -1,7 +1,7 @@
 # Managed by Ansible
 server {
   listen      443;
-  server_name files.pydis.wtf;
+  server_name files.pydis.wtf cloud.native.is.fun.and.easy.pydis.wtf;
   root        /var/www/turing;
 
   location / {


### PR DESCRIPTION
Previously the files server would return a HTTP 500 if a matching file was not
found, since internally NGINX would fall into a redirect loop trying to locate
the relevant file.

This adds a final 404 fallback handler so if there is not a direct match we
return an error instead of returning a HTTP 500.