### PR TITLE
Fix AlertManager Discord instance formatting

### DIFF
--- a/kubernetes/namespaces/monitoring/alerts/alertmanager.yaml
+++ b/kubernetes/namespaces/monitoring/alerts/alertmanager.yaml
@@ -22,7 +22,7 @@ receivers:
         title: '{{ if eq .Status "firing" }}[FIRING]{{ else }}[RESOLVED]{{ end }}'
         text: |
           {{ if eq .Status "firing" }}{{ range .Alerts }}
-          `{{ .Labels.instance }}`: **{{ .Annotations.summary }}:**
+          {{ if .Labels.instance }}`{{ .Labels.instance }}`: {{ end }}**{{ .Annotations.summary }}:**
           {{ .Annotations.description }} [(Link)]({{.GeneratorURL}})
 
           {{ end }}{{ else }}Alert has resolved.{{ end }}


### PR DESCRIPTION
We made a change to include the instance in alerts sent to Discord, but
not all of our configured alerts send this field.

As a result, we would have incorrectly formatted alerts being sent
through to Discord which were tricky to read.

The format template has now been changed to only conditionally render
the instance label if it is present on a triggered alert.