### PR TITLE
Group and deploy certificates per target host

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,6 +1,7 @@
 - name: Deploy common services
   hosts: all
   roles:
+    - certbot
     - common
     - pydis-users
     - nftables
@@ -16,10 +17,9 @@
     - prometheus
     - prometheus-blackbox-exporter
 
-- name: Deploy nginx & certbot to hosts
+- name: Deploy nginx to hosts
   hosts: nginx
   roles:
-    - certbot
     - nginx
     - nginx-geoip
     - nginx-cloudflare-mtls

--- a/ansible/roles/certbot/tasks/main.yml
+++ b/ansible/roles/certbot/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Install certbot and certbot Cloudflare plugin
-  when: inventory_hostname == ansible_play_hosts_all[0]
   package:
     name:
       - python3-certbot
@@ -9,15 +8,8 @@
   tags:
     - role::certbot
 
-- name: Install rsync on certbot hosts
-  package:
-    name: rsync
-    state: present
-  tags:
-    - role::certbot
 
-- name: Generate Cloudflare credentials file on designated leader
-  when: inventory_hostname == ansible_play_hosts_all[0]
+- name: Generate Cloudflare credentials file
   copy:
     content: |
       # This file is managed by Ansible
@@ -29,21 +21,8 @@
   tags:
     - role::certbot
 
-- name: Generate SSH key for certificate distribution
-  when: inventory_hostname == ansible_play_hosts_all[0]
-  community.crypto.openssh_keypair:
-    path: /root/.ssh/cert_{{ item }}_key_ed25519
-    type: ed25519
-    state: present
-    comment: certificate distribution key for {{ item }}
-  with_items:
-    - "{{ ansible_play_hosts | reject('in', [inventory_hostname]) }}"
-  tags:
-    - role::certbot
-  register: generated_keys
 
-- name: Create certificate directories on replica certificate hosts
-  when: inventory_hostname != ansible_play_hosts[0]
+- name: Create certificate directories on hosts
   file:
     path: /etc/letsencrypt/live
     recurse: true
@@ -54,40 +33,8 @@
   tags:
     - role::certbot
 
-- name: Install certificate distribution keys to other NGINX nodes
-  when: inventory_hostname != ansible_play_hosts[0]
-  ansible.posix.authorized_key:
-    user: root
-    state: present
-    key: |
-      {{ hostvars[ansible_play_hosts_all[0]]['generated_keys']['results']
-      | selectattr('item', 'equalto', inventory_hostname)
-      | map(attribute='public_key')
-      | first }}
-    comment: "certificate distribution key"
-    key_options: 'from="{{ hostvars[ansible_play_hosts_all[0]]["wireguard_subnet"] }}",restrict,command="/opt/cert_rsync.sh"'
-  tags:
-    - role::certbot
-
-- name: Ensure renewal-hooks deploy directory exists
-  file:
-    path: /etc/letsencrypt/renewal-hooks/deploy
-    recurse: true
-    state: directory
-
-- name: Create renewal hook to synchronize certificates
-  when: inventory_hostname == ansible_play_hosts_all[0]
-  template:
-    src: renewal-hook.sh.j2
-    dest: /etc/letsencrypt/renewal-hooks/deploy/distribute-certs
-    owner: root
-    group: root
-    mode: "0700"
-  tags:
-    - role::certbot
 
 - name: Request certificates for configured domains
-  when: inventory_hostname == ansible_play_hosts_all[0]
   command: |
     certbot certonly
     --agree-tos
@@ -95,11 +42,10 @@
     --email {{ certbot_email }}
     --dns-cloudflare
     --dns-cloudflare-credentials /etc/letsencrypt/cloudflare.ini
-    --deploy-hook /etc/letsencrypt/renewal-hooks/deploy/distribute-certs
-    -d {{ item }} -d *.{{ item }} -d cloud.native.is.fun.and.easy.pydis.wtf
+    -d {{ item }} -d {{inventory_hostname}}.box.pydis.wtf
   args:
     creates: "/etc/letsencrypt/live/{{ item }}/fullchain.pem"
   with_items:
-    - "{{ certbot_domains }}"
+    - "{{ certbot_domains[inventory_hostname] }}"
   tags:
     - role::certbot

--- a/ansible/roles/certbot/templates/renewal-hook.sh.j2
+++ b/ansible/roles/certbot/templates/renewal-hook.sh.j2
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -ex
-
-{% for host in ansible_play_hosts if host != inventory_hostname %}
-rsync --copy-links --delete --recursive -e "ssh -i /root/.ssh/cert_{{ host }}_key_ed25519 -o StrictHostKeyChecking=accept-new" /etc/letsencrypt/live/* root@{{ hostvars[host]['wireguard_subnet'] | split("/") | first }}:/etc/letsencrypt/live
-{% endfor %}

--- a/ansible/roles/certbot/vars/main/main.yml
+++ b/ansible/roles/certbot/vars/main/main.yml
@@ -2,6 +2,9 @@
 certbot_cloudflare_token: "{{ encrypted_cloudflare_token }}"
 certbot_email: "joe@jb3.dev"
 certbot_domains:
-  - pydis.wtf
-  - pythondiscord.com
-  - prometheus.lovelace.box.pydis.wtf
+  lovelace:
+    - prometheus.lovelace.box.pydis.wtf
+  turing:
+    - pydis.wtf
+    - "*.pydis.wtf"
+    - cloud.native.is.fun.and.easy.pydis.wtf


### PR DESCRIPTION
This alters the `certbot` role to have a set of domains for which we'd like to generate certificates per host instead of centralizing them on a main host then distribute them.

Closes #313