### PR TITLE
Open port 9090 to allow hitting the prometheus instance

### DIFF
--- a/ansible/group_vars/all/nftables.yml
+++ b/ansible/group_vars/all/nftables.yml
@@ -60,6 +60,15 @@ nftables_configuration: |
       iifname {{ ansible_default_ipv6.interface }} udp dport {{ wireguard_port }} ct state new accept
   {% endif %}
 
+
+  {% if "monitoring" in group_names %}
+      # Prometheus connections
+      iifname {{ ansible_default_ipv4.interface }} tcp dport 9090 ct state new accept
+  {% if ansible_default_ipv6 is defined %}
+      iifname {{ ansible_default_ipv6.interface }} tcp dport 9090 ct state new accept
+  {% endif %}
+  {% endif %}
+
   {% if "databases" in group_names %}
       # PostgreSQL connections
       iifname {{ ansible_default_ipv4.interface }} ip saddr @possible_lke_ipv4_addrs tcp dport postgresql ct state new accept

--- a/ansible/host_vars/lovelace/prometheus.yml
+++ b/ansible/host_vars/lovelace/prometheus.yml
@@ -1,4 +1,13 @@
 ---
+
+prometheus_cmdline_options: " --web.config.file=/etc/prometheus/web_config.yml"
+
+prometheus_web_configuration:
+  tls_server_config:
+    cert_file: "/etc/letsencrypt/live/prometheus.{{ inventory_hostname }}.box.pydis.wtf/fullchain.pem"
+    key_file: "/etc/letsencrypt/live/prometheus.{{ inventory_hostname }}.box.pydis.wtf/privkey.pem"
+
+
 prometheus_configuration:
   global:
     scrape_interval: 15s  # Set the scrape interval to every 15 seconds. Default is every 1 minute.

--- a/ansible/inventory/hosts.yaml
+++ b/ansible/inventory/hosts.yaml
@@ -13,5 +13,8 @@ all:
     databases:
       hosts:
         lovelace:
+    monitoring:
+      hosts:
+        lovelace:
   vars:
     wireguard_port: 46850

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -12,7 +12,7 @@
     - unattended-upgrades
 
 - name: Deploy our monitoring stack
-  hosts: lovelace
+  hosts: monitoring
   roles:
     - prometheus
     - prometheus-blackbox-exporter

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -18,12 +18,26 @@
   notify:
     - Restart the prometheus service
 
-- name: Configure prometheus
+- name: Deploy prometheus general config
   copy:
     content: |
       # Ansible managed
       {{ prometheus_configuration | to_nice_yaml }}
     dest: /etc/prometheus/prometheus.yml
+    owner: prometheus
+    group: prometheus
+    mode: "0400"
+  tags:
+    - role::prometheus
+  notify:
+    - Reload the prometheus service
+
+- name: Deploy prometheus web server config
+  copy:
+    content: |
+      # Ansible managed
+      {{ prometheus_web_configuration | to_nice_yaml }}
+    dest: /etc/prometheus/web_config.yml
     owner: prometheus
     group: prometheus
     mode: "0400"


### PR DESCRIPTION
This PR adds the necessary nftables ruls to allow traffic to our prometheus instance

It also updates prometheu's webconfig to use tls encryption when running the server.