### PR TITLE
[ansible] Add new cert-users group for certificate read access

### DIFF
--- a/ansible/roles/certbot/tasks/main.yml
+++ b/ansible/roles/certbot/tasks/main.yml
@@ -22,14 +22,25 @@
     - role::certbot
 
 
+- name: Create cert-users group
+  group:
+    name: cert-users
+    state: present
+  tags:
+    - role::certbot
+
+
 - name: Create certificate directories on hosts
   file:
-    path: /etc/letsencrypt/live
+    path: '{{ item }}'
     recurse: true
     state: directory
     owner: root
-    group: root
-    mode: "0700"
+    group: cert-users
+    mode: "0750" # User rwx, Group rx
+  with_items:
+    - /etc/letsencrypt/live
+    - /etc/letsencrypt/archive
   tags:
     - role::certbot
 
@@ -47,5 +58,17 @@
     creates: "/etc/letsencrypt/live/{{ item }}/fullchain.pem"
   with_items:
     - "{{ certbot_domains[inventory_hostname] }}"
+  tags:
+    - role::certbot
+
+
+- name: Add authorized users to cert-users group
+  user:
+    name: '{{ item }}'
+    groups: cert-users
+    append: true
+  with_items:
+    - "{{ certbot_cert_users[inventory_hostname] }}"
+  when: "inventory_hostname in certbot_cert_users"
   tags:
     - role::certbot

--- a/ansible/roles/certbot/vars/main/main.yml
+++ b/ansible/roles/certbot/vars/main/main.yml
@@ -8,3 +8,7 @@ certbot_domains:
     - pydis.wtf
     - "*.pydis.wtf"
     - cloud.native.is.fun.and.easy.pydis.wtf
+
+certbot_cert_users:
+  lovelace:
+    - prometheus


### PR DESCRIPTION
Change certificate directory ownership to cert-users group

This allows for non-root services that are in the cert-users group to still
access and read certificate data that they need in order to operate.

Doing things this way means that services still refer to a
single-source-of-truth for the certificate store whilst retaining their non-root
and non-privileged nature.