### PR TITLE
Enable mTLS on Prometheus deployment

### DIFF
--- a/ansible/host_vars/lovelace/prometheus.yml
+++ b/ansible/host_vars/lovelace/prometheus.yml
@@ -11,6 +11,9 @@ prometheus_web_configuration:
     cert_file: "/etc/letsencrypt/live/prometheus.{{ inventory_hostname }}.box.pydis.wtf/fullchain.pem"
     key_file: "/etc/letsencrypt/live/prometheus.{{ inventory_hostname }}.box.pydis.wtf/privkey.pem"
 
+    # mTLS preferences
+    client_auth_type: RequireAndVerifyClientCert
+    client_ca_file: /opt/pydis/ca.pem
 
 prometheus_configuration:
   global:

--- a/ansible/host_vars/lovelace/prometheus.yml
+++ b/ansible/host_vars/lovelace/prometheus.yml
@@ -15,6 +15,9 @@ prometheus_web_configuration:
     client_auth_type: RequireAndVerifyClientCert
     client_ca_file: /opt/pydis/ca.pem
 
+    client_allowed_sans:
+      - prometheus.access.tls.pydis.wtf
+
 prometheus_configuration:
   global:
     scrape_interval: 15s  # Set the scrape interval to every 15 seconds. Default is every 1 minute.

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -79,7 +79,7 @@
   tags:
     - role::prometheus
   notify:
-    - Reload the prometheus service
+    - Restart the prometheus service
 
 - name: Configure prometheus rules
   copy:


### PR DESCRIPTION
This PR enables mTLS on our Prometheus deployment and validates certificates
against the Certificate Authority distributed to all hosts as a part of #319.

Due to an unfortunate lag in the Debian stable repositories, this PR does not
currently work and is rejecting certificates which are otherwise valid. Debian
currently has Prometheus 2.42.0 as it's stable version[^1], this released on
February 1st 2023.

Even the LTS release of Prometheus (2.45) has not yet graduated past the Debian
testing repositories.

I have validated that the certificates and CA *are* valid with:
- a [tiny mTLS server I wrote](https://gist.github.com/jb3/0b04df62a19dbde8acedf30a6f527270) using the same crypto/TLS libraries that Prometheus uses
- the latest version of Prometheus (`prom/prometheus:latest`, as we run in
  Kubernetes)

Both of the above accept, validate and admit requests, only the version which
Debian stable is stuck on does not correctly admit requests.

I have marked this PR as a draft due to the unforeseen complications caused by
the out-of-date version. We can discuss this at the DevOps meeting on Tuesday
evening.

[^1]: https://tracker.debian.org/pkg/prometheus