### PR TITLE
Make issuing pg grants configurable

### DIFF
--- a/ansible/roles/postgres/README.md
+++ b/ansible/roles/postgres/README.md
@@ -1,0 +1,36 @@
+# Role "postgres"
+
+Installs and configures the postgres cluster.
+
+
+## Variables
+
+- `postgres_version` The postgres version to be installed.
+- `postgres_user` The user that owns root access to the postgres cluster
+- `postgres_users` The list of postgres users that have restricted access to the postgres cluster. Each user needs to have
+  the following attributes defined:
+  - `name`: The user's login name
+  - `password`: The user's password
+  - `roles`: A list of roles that will be assigned to the user. You can read more about them here https://www.postgresql.org/docs/current/user-manag.html
+
+- `postgres_hba_rules` The postgres cluster's host based authentication configuration.
+   All the following attributes can be found in detail here https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
+  - `conn_type`: The connection type allowed to connect to the cluster.
+  - `database`: The database that the user who's trying to connect is allowed to access.
+  - `user`: The user's login name
+  - `address`: The ip address or addresses to be allowed to connect from.
+  - `method`: The login method.
+
+- `postgres_databases` The list of databases that will be created in the cluster
+  - `name`: The database's name
+    `owner`: The owner of the database, this is equivalent to the `postgres_users.name`
+
+
+`postgres_grants` The list of access privileges that will be granted to specific roles/users. You can read more about these
+  In the official docs https://www.postgresql.org/docs/current/sql-grant.html
+  The specific values these variables can take can be found here https://docs.ansible.com/ansible/latest/collections/community/postgresql/postgresql_privs_module.html
+ - `roles`: Comma separated list of role (user/group) names to set permissions for.
+ - `database`: Name of database to connect to.
+ - `state`: The state of the privilege, `present` to grant them and `absent` to revoke them.
+ - `privs`: Comma separated list of privileges to grant/revoke.
+ - `objs`: Comma separated list of database objects to set privileges on.

--- a/ansible/roles/postgres/tasks/main.yml
+++ b/ansible/roles/postgres/tasks/main.yml
@@ -72,6 +72,23 @@
   tags:
     - role::postgres
 
+- name: Grant specified grants to particular roles
+  community.postgresql.postgresql_privs:
+    database: "{{ grant.database }}"
+    state: "{{ grant.state }}"
+    privs: "{{ grant.privs }}"
+    objs: "{{ grant.objs }}"
+    roles: "{{ grant.roles }}"
+  when: postgres_grants is defined
+  loop: "{{ postgres_grants }}"
+  loop_control:
+    loop_var: grant
+    label: "{{ grant.privs }} --> {{ grant.roles }}"
+  become: true
+  become_user: "{{ postgres_user }}"
+  tags:
+    - role::postgres
+
 - name: Import postgresql.conf
   copy:
     src: postgresql.conf


### PR DESCRIPTION
This adds a task that allows issuing particular grants to specific roles in postgres