### PR TITLE
Switch to using designated placeholder IPv4 for originless records

### DIFF
--- a/dns/zones/pydis.wtf.yaml
+++ b/dns/zones/pydis.wtf.yaml
@@ -5,7 +5,7 @@
         proxied: true
     ttl: 300
     type: A
-    value: 1.2.3.4
+    value: 192.0.2.0 # Reserved placeholder IPv4 address
   - octodns:
       cloudflare:
         auto-ttl: true
@@ -127,7 +127,7 @@ paste:
       proxied: true
   ttl: 300
   type: A
-  value: 1.2.3.4
+  value: 192.0.2.0
 
 pddc.devops:
   octodns:

--- a/dns/zones/pythondiscord.com.yaml
+++ b/dns/zones/pythondiscord.com.yaml
@@ -86,7 +86,7 @@ challenge:
       proxied: true
   ttl: 300
   type: A
-  value: 1.1.1.1
+  value: 192.0.2.0 # Placeholder IPv4 address
 
 csp:
   octodns:


### PR DESCRIPTION
We currently used something like 1.2.3.4 or 1.1.1.1 as placeholder IP
addresses for DNS records where we ran in "originless" mode (the request
is always answered by a Cloudflare Worker or a redirect).

This changes that so we use designated reserved IPv4
addresses (192.0.2.0) to capture that traffic instead, ensuring that in
no circumstance would we leak traffic to an address like 1.1.1.1 or
1.2.3.4 if there was a Cloudflare misconfiguration.

Despite the potential risk vectors here being very small, it's a minor
change and also helps us ensure configuration works correctly in the future.