### PR TITLE
Add Metricity manifest

### DIFF
--- a/kubernetes/namespaces/bots/metricity/deployment.yaml
+++ b/kubernetes/namespaces/bots/metricity/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metricity
+  namespace: bots
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: metricity
+  template:
+    metadata:
+      labels:
+        app: metricity
+    spec:
+      securityContext:
+        fsGroup: 2000
+        runAsUser: 1000
+        runAsNonRoot: true
+      containers:
+        - name: metricity
+          image: ghcr.io/python-discord/metricity:latest
+          imagePullPolicy: "Always"
+          envFrom:
+            - secretRef:
+                name: metricity-env
+          securityContext:
+            readOnlyRootFilesystem: true


### PR DESCRIPTION
Copies the Metricity deployment manifest from the Metricity repo.

Once this PR has merged, I will update the metricity repo to use this manifest
on deployment instead of the in-repo one.