### PR TITLE
Sudo with NOPASSWD

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -7,7 +7,6 @@ roles_path = .ansible/galaxy_roles/:roles/
 
 [privilege_escalation]
 become = yes
-become_ask_pass = yes
 
 [connection]
 pipelining = True

--- a/ansible/roles/common/templates/sudoers.j2
+++ b/ansible/roles/common/templates/sudoers.j2
@@ -1,4 +1,6 @@
 Defaults lecture_file="/etc/sudo_lecture"
 Defaults insults
 
+%sudo    ALL=(ALL) NOPASSWD:ALL
+
 # vim: ft=sudoers.j2:


### PR DESCRIPTION
- Add new sudoers rule for `sudo` group to not require a password for sudo.
  - We already perform a decent level of security verification for logins,
    requiring SSH keys and only permitting certain usernames, as well as being
    cautious of the users we grant `sudo` group access to.
  - As such, usage of the `sudo` command is much more a failsafe technique to
    ensure people know what they are running than a security measure.
  - For ease of use, we do not need a password for these commands, password
    fatigue often means that people care *less* when a password requirement is
    in place.
- Additional to this, I have removed the `become_ask_pass` configuration option
  for Ansible to remove Ansible asking for a password upon deployment.