### PR TITLE
Add a preStop hook to site to close all connections

### DIFF
--- a/kubernetes/namespaces/web/site/deployment.yaml
+++ b/kubernetes/namespaces/web/site/deployment.yaml
@@ -19,6 +19,10 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
+          lifecyle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "python manage.py close_db_connections"]
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
This is to ensure that the connections opened from the pod that's about to be killed/replaced are closed beforehand.
