### PR TITLE
Rename relabelledpods to just pods

### DIFF
--- a/kubernetes/namespaces/loki/alloy_values.yml
+++ b/kubernetes/namespaces/loki/alloy_values.yml
@@ -63,7 +63,7 @@ alloy:
       }
 
       // Write all values into the Loki receiver
-      loki.source.kubernetes "relabelledpods" {
+      loki.source.kubernetes "pods" {
         targets    = discovery.relabel.pods.output
         forward_to = [loki.write.local.receiver]
       }


### PR DESCRIPTION
This was a redundant rename and reduced the clarity of jobs when
querying from inside Grafana.

This rectifies that by renaming the stream to just `pods`.