### PR TITLE
Update site to run migrations in an init container

### DIFF
--- a/kubernetes/namespaces/web/site/deployment.yaml
+++ b/kubernetes/namespaces/web/site/deployment.yaml
@@ -18,9 +18,9 @@ spec:
           image: ghcr.io/python-discord/site:latest
           imagePullPolicy: Always
           command:
-            - sh
-            - -c
-            - "poetry run python manage.py migrate"
+            - python
+            - manage.py
+            - migrate
           envFrom:
             - secretRef:
                 name: site-env

--- a/kubernetes/namespaces/web/site/deployment.yaml
+++ b/kubernetes/namespaces/web/site/deployment.yaml
@@ -13,6 +13,19 @@ spec:
       labels:
         app: site
     spec:
+      initContainers:
+        - name: migrations
+          image: ghcr.io/python-discord/site:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - "poetry run python manage.py migrate"
+          envFrom:
+            - secretRef:
+                name: site-env
+          securityContext:
+            readOnlyRootFilesystem: true
       containers:
         - name: site
           image: ghcr.io/python-discord/site:latest


### PR DESCRIPTION
In accordance with updates from python-discord/site#1338 this changes
the way migrations are run.

Previously, migrations would be run all from within the manage.py
execution process with the command being manually spawned using Django
internals.

After python-discord/site#1338 merges the Dockerfile will directly
invoke gunicorn and bypass manage.py to simplify the process and avoid
problems with shared database contexts.

Hence, we need to manually run migrations using an init container. With
testing there is no additional delay in doing this as spinning up an
init container is cheap and we don't cut over any traffic until the site
passes a healthcheck anyway.