### PR TITLE
Loki retention preferences

### DIFF
--- a/kubernetes/namespaces/loki/loki_values.yml
+++ b/kubernetes/namespaces/loki/loki_values.yml
@@ -24,8 +24,13 @@ loki:
   storage:
     type: s3
 
-  # Enable volume querying endpoint (for Grafana Explore Logs)
+  compactor:
+    retention_enabled: true
+    delete_request_store: s3
+    delete_request_cancel_period: 1h
+
   limits_config:
+    # Enable volume querying endpoint (for Grafana Explore Logs)
     volume_enabled: true
 
 singleBinary:


### PR DESCRIPTION
Update Loki config with new compactor preferences for retention modes

* `retention_enabled`: enable retention mode within the compactor
* `delete_request_store`: store deletion requests within the s3 cluster
  that is also used to house log chunks
* `delete_request_cancel_period`: do not exercise log deletion
  instructions until at least one hour has passed to prevent accidental
  deletion

This PR does not set a retention duration so we still retain logs indefinitely
as of now but:
* in future we can add this preference to enable log deletion
* this enables the API endpoints allowing for manual deletion requests,
  optionally doing so conditionally based on a query selector