### PR TITLE
Deployment of a finger server

### DIFF
--- a/dns/zones/pydis.wtf.yaml
+++ b/dns/zones/pydis.wtf.yaml
@@ -2,10 +2,10 @@
 '':
   - octodns:
       cloudflare:
-        proxied: true
+        proxied: false
     ttl: 300
     type: A
-    value: 192.0.2.0 # Reserved placeholder IPv4 address
+    value: 89.58.25.151
   - octodns:
       cloudflare:
         auto-ttl: true


### PR DESCRIPTION
This allows for external users to check on the status of the DevOps team using
the [finger](https://en.wikipedia.org/wiki/Finger_(protocol)) protocol.

Documentation is provided on establishing your plan as well as opting-out of the
finger system.