### PR TITLE
Verify git commit authenticity

### DIFF
--- a/.github/workflows/authenticate.yaml
+++ b/.github/workflows/authenticate.yaml
@@ -1,0 +1,19 @@
+name: Verify commit authenticity
+on:
+  push:
+jobs:
+  verify-commits:
+    name: Verify commit authenticity using Guix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Fetch the entire history
+          fetch-depth: 0
+      - name: Fetch keyring branch
+        run: git fetch origin keyring && git checkout keyring && git checkout -
+      - name: Install Guix
+        run: sudo apt-get update -y && sudo apt-get install -y guix
+      - name: Authenticate git commits
+        # guix git authenticate $INITIAL_AUTHENTICATED_COMMIT_SHA $SIGNER_PGP_FINGERPRINT
+        run: guix git authenticate 31c3821ce936b4d70924f76431b0ce25235f76f0 8C05D0E98B7914EDEBDCC8CC8E8E09282F2E17AF --stats

--- a/.guix-authorizations
+++ b/.guix-authorizations
@@ -1,5 +1,10 @@
 ;; To retrieve a fingerprint, run:
+;;
 ;;   gpg --fingerprint userid
+;;
+;; The fingerprints in here have their corresponding public keys stored on the
+;; `keyring` branch. If you add a new key here, you will want to add it there
+;; as well.
 (authorizations
   (version 0)
   (("509C DFFC 2D07 83A3 3CF8  7D2B 703E E21D E4D4 D9C9"
@@ -9,6 +14,8 @@
    ("1DA9 1E6C E87E 3C1F CE32  BC0C B6ED 85CC 5872 D5E4"
     (name "chris"))
    ("1C9F 6546 FF9B 7C1B 097C  B9D6 8A4B F233 DB1D 650A"
-    (name "bella"))))
+    (name "bella"))
+   ("9684 79A1 AFF9 27E3 7D1A  566B B569 0EEE BB95 2194"
+    (name "github-bot"))))
 
 ;; vim: ft=scheme:

--- a/README.md
+++ b/README.md
@@ -33,3 +33,31 @@ Infrastructure-related documentation ("the big picture"), can be found in [`docs
 
 Many folders have a `README.md` file within them, which have more detailed explanations on what
 that folder, and the files within, is used for.
+
+
+## Commit verification
+
+All commits on the `main` branch are signed by the DevOps team members, which
+is verified via our [GitHub workflow to run `guix git
+authenticate`](.github/workflows/authenticate.yml).
+
+Due to the access to sensitive data we have, we need to ensure that we can
+trust what we are running on both our computers and deploying into the cluster.
+All DevOps team members are therefore strongly encouraged to incorporate this
+setup into their local setup. Installing GNU Guix (`apt install guix`) and
+running the following command will get you started:
+
+```sh
+guix git authenticate 31c3821ce936b4d70924f76431b0ce25235f76f0 8C05D0E98B7914EDEBDCC8CC8E8E09282F2E17AF
+```
+
+This will install `pre-push` and `pre-merge` hooks that authenticate the
+repository anytime you run `git pull` or `git push`, ensuring only approved
+commiters get their code on your machine.
+
+If you are curious why we use this when GitHub already marks signed commits
+with a checkmark, the reason is that GitHub's checkmark only states that a
+commit was signed, but that on its own does not _authenticate_ whether that
+commit is signed by a trusted key. More information can be found at
+[Authenticate your Git
+checkouts!](https://guix.gnu.org/en/blog/2024/authenticate-your-git-checkouts/).


### PR DESCRIPTION
This pull request introduces a mechanism to verify the authenticity of GPG signatures made on our commits, starting from commit 31c3821ce936b4d70924f76431b0ce25235f76f0.

The goal is to allow us to ensure that any commits that we pull onto our local machines (and possibly, but this isn't currently set up as a hard check in CI, our remote hosts) are authentic commits from known DevOps team members to prevent executing untrusted code and deployments locally.

The README has been updated to include instructions for how to set it up locally. Running the command once is suffícient to install hooks that verify further pushes.
