### PR TITLE
Add new host `ldap01.box.pydis.wtf`

### DIFF
--- a/ansible/host_vars/lovelace/prometheus.yml
+++ b/ansible/host_vars/lovelace/prometheus.yml
@@ -1,5 +1,4 @@
 ---
-
 prometheus_cmdline_options: >-
   --config.file=/etc/prometheus/prometheus.yml
   --web.page-title='Python Discord Helper Monitoring And Supervision Service'
@@ -44,8 +43,8 @@ prometheus_configuration: |
       # Scrape node exporters on all hosts
       static_configs:
         - targets:
-          {%- for host in hostvars.values() %}
-          - {{ host['ansible_wg0']['ipv4']['address'] }}:9100
+          {%- for host in groups['netcup'] %}
+          - {{ hostvars[host]['ansible_wg0']['ipv4']['address'] }}:9100
           {%- endfor %}
 
     - job_name: postgres

--- a/ansible/inventory/hosts.yaml
+++ b/ansible/inventory/hosts.yaml
@@ -6,7 +6,13 @@ all:
     lovelace:
       ansible_host: lovelace.box.pydis.wtf
       wireguard_subnet: 10.2.0.0/16
+    ldap01:
+      ansible_host: ldap01.box.pydis.wtf
   children:
+    netcup:
+      hosts:
+        turing:
+        lovelace:
     nginx:
       hosts:
         turing:

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,10 +1,14 @@
 - name: Deploy common services
   hosts: all
   roles:
-    - pydis-mtls
-    - certbot
-    - common
     - pydis-users
+    - common
+    - pydis-mtls
+
+- name: Deploy services to Netcup nodes
+  hosts: netcup
+  roles:
+    - certbot
     - alloy
     - nftables
     - prometheus-node-exporter

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -8,7 +8,7 @@
   template:
     src: etc-hosts.j2
     dest: /etc/hosts
-    mode: '0644'
+    mode: "0644"
     owner: root
     group: root
   tags:
@@ -35,7 +35,8 @@
     group: root
     mode: "0444"
   notify:
-    - Reload ssh
+    - Reload ssh (Debian)
+    - Reload sshd (Rocky)
   tags:
     - role::common
 
@@ -58,7 +59,7 @@
   file:
     src: /usr/share/zoneinfo/Etc/UTC
     dest: /etc/localtime
-    mode: '0644'
+    mode: "0644"
     owner: root
     group: root
   notify:
@@ -70,7 +71,7 @@
   template:
     src: sudo_lecture.j2
     dest: /etc/sudo_lecture
-    mode: '0644'
+    mode: "0644"
     owner: root
     group: root
   tags:
@@ -82,7 +83,7 @@
     dest: /etc/sudoers.d/pydis
     owner: root
     group: root
-    mode: '0440'
+    mode: "0440"
     validate: /usr/sbin/visudo -cf %s
   tags:
     - role::common
@@ -91,7 +92,7 @@
   template:
     src: motd.j2
     dest: /etc/motd
-    mode: '0644'
+    mode: "0644"
     owner: root
     group: root
   tags:
@@ -102,7 +103,7 @@
     src: /etc/skel/.bashrc
     dest: /root/.bashrc
     remote_src: true
-    mode: '0644'
+    mode: "0644"
     owner: root
     group: root
   tags:
@@ -117,10 +118,19 @@
   tags:
     - role::common
 
-- name: Install larger system administration tools
+- name: Install larger system administration tools (Debian)
   apt:
     name: emacs-nox
     install_recommends: false
     state: present
+  when: ansible_distribution == "Debian"
+  tags:
+    - role::common
+
+- name: Install larger system administration tools (Rocky)
+  package:
+    name: emacs-nox
+    state: present
+  when: ansible_distribution == "Rocky"
   tags:
     - role::common

--- a/ansible/roles/pydis-users/tasks/main.yml
+++ b/ansible/roles/pydis-users/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: Create sudo group
+  ansible.builtin.group:
+    name: sudo
+    state: present
+  tags:
+    - role::pydis-users
+
 - name: Create users
   ansible.builtin.user:
     name: "{{ item.key }}"
@@ -37,6 +44,7 @@
     group: root
     mode: "0444"
   notify:
-    - Reload ssh
+    - Reload ssh (Debian)
+    - Reload sshd (Rocky)
   tags:
     - role::pydis-users

--- a/ansible/roles/ssh/handlers/main.yml
+++ b/ansible/roles/ssh/handlers/main.yml
@@ -1,7 +1,16 @@
 ---
-- name: Reload ssh
+- name: Reload ssh (Debian)
   service:
     name: ssh
     state: reloaded
+  when: ansible_distribution == "Debian"
+  tags:
+    - role::ssh
+
+- name: Reload sshd (Rocky)
+  service:
+    name: sshd
+    state: reloaded
+  when: ansible_distribution == "Rocky"
   tags:
     - role::ssh

--- a/ansible/roles/wireguard/tasks/main.yml
+++ b/ansible/roles/wireguard/tasks/main.yml
@@ -27,10 +27,10 @@
 
 - name: Ensure file permissions for keys set correctly
   file:
-    path: '{{ item }}'
+    path: "{{ item }}"
     owner: root
     group: root
-    mode: '0600'
+    mode: "0600"
   with_items:
     - /etc/wireguard/key.priv
     - /etc/wireguard/key.pub
@@ -55,7 +55,7 @@
   template:
     src: wg0.conf.j2
     dest: /etc/wireguard/wg0.conf
-    mode: '0600'
+    mode: "0600"
     group: root
     owner: root
   notify:

--- a/ansible/roles/wireguard/templates/wg0.conf.j2
+++ b/ansible/roles/wireguard/templates/wg0.conf.j2
@@ -6,7 +6,7 @@ PrivateKey = {{ wg_priv_key['content'] | b64decode | trim }}
 
 PostUp = ip route add local {{ wireguard_subnet }} dev eth0
 
-{% for host in hostvars.keys() if not host == inventory_hostname %}
+{% for host in groups["netcup"] if not host == inventory_hostname %}
 # Peer config for: {{ host }}
 [Peer]
 AllowedIPs = {{ hostvars[host]['wireguard_subnet'] }}

--- a/dns/zones/pydis.wtf.yaml
+++ b/dns/zones/pydis.wtf.yaml
@@ -1,5 +1,5 @@
 ---
-'':
+"":
   - octodns:
       cloudflare:
         proxied: true
@@ -12,20 +12,20 @@
     ttl: 300
     type: MX
     values:
-    - exchange: amir.mx.cloudflare.net.
-      preference: 36
-    - exchange: isaac.mx.cloudflare.net.
-      preference: 60
-    - exchange: linda.mx.cloudflare.net.
-      preference: 85
+      - exchange: amir.mx.cloudflare.net.
+        preference: 36
+      - exchange: isaac.mx.cloudflare.net.
+        preference: 60
+      - exchange: linda.mx.cloudflare.net.
+        preference: 85
   - octodns:
       cloudflare:
         auto-ttl: true
     ttl: 300
     type: TXT
     values:
-    - keybase-site-verification=mKEPFr6d5VSGgahHtzy0y7nPRmo7OWyOUQ7s9ds8OFs
-    - v=spf1 include:_spf.mx.cloudflare.net ~all
+      - keybase-site-verification=mKEPFr6d5VSGgahHtzy0y7nPRmo7OWyOUQ7s9ds8OFs
+      - v=spf1 include:_spf.mx.cloudflare.net ~all
 
 20220929._domainkey:
   octodns:
@@ -98,6 +98,15 @@ id:
   ttl: 300
   type: A
   value: 194.195.247.228
+
+ldap01.box:
+  octodns:
+    cloudflare:
+      auto-ttl: true
+      proxied: false
+  ttl: 300
+  type: A
+  value: 139.162.163.212
 
 loki-gateway:
   octodns:


### PR DESCRIPTION
- Add new host `ldap01.box.pydis.wtf`, which will be the domain controller for
  pydis.wtf
- Split netcup services so that we don't deploy Debian specific services which
  we do not need on the domain controller to this server
- Update SSH role to handle SSH reloads on both operating systems
- Explicitly create a sudo group for Rocky servers
- Install emacs seperately on Rocky servers

Down the line, I think that enabling WireGuard on this host as well as other
services (e.g. Alloy) could be cool, but given that it will require fundamental
rewrites of the role my goal here is to get the server functioning and look at
integration afterwards.