### PR TITLE
Add DNS entry for propaganda

### DIFF
--- a/dns/zones/pydis.wtf.zone/root.yaml
+++ b/dns/zones/pydis.wtf.zone/root.yaml
@@ -172,6 +172,14 @@ prometheus:
   type: CNAME
   value: linode-lb.box.pydis.wtf.
 
+propaganda:
+  octodns:
+    cloudflare:
+      auto-ttl: true
+  ttl: 300
+  type: CNAME
+  value: lovelace.box.pydis.wtf.
+
 vault:
   octodns:
     cloudflare:


### PR DESCRIPTION
This commit adds a new DNS entry, used for storing Python
Discord-related propaganda, including, but not limited to, Soviet
propaganda, including, but not limited to, pictures of Joe Banks wearing
Ushankas and fan articles about Ivan Drago, as well as propaganda
displaying Joe Banks in various heroic settings.
