### PR TITLE
Update certificate issuance to group together related certificates

### DIFF
--- a/ansible/host_vars/lovelace/nginx.yml
+++ b/ansible/host_vars/lovelace/nginx.yml
@@ -31,6 +31,9 @@ nginx_configs:
       server_name files.pydis.wtf cloud.native.is.fun.and.easy.pydis.wtf;
       root        /var/www/files.pydis.wtf;
 
+      ssl_certificate         /etc/letsencrypt/live/pydis.wtf/fullchain.pem;
+      ssl_certificate_key     /etc/letsencrypt/live/pydis.wtf/privkey.pem;
+
       location / {
         try_files $uri $uri/ =404;
       }

--- a/ansible/roles/certbot/tasks/main.yml
+++ b/ansible/roles/certbot/tasks/main.yml
@@ -56,7 +56,7 @@
     --dns-cloudflare-credentials /etc/letsencrypt/cloudflare.ini
     -d {{ item }}
   args:
-    creates: "/etc/letsencrypt/live/{{ item }}/fullchain.pem"
+    creates: "/etc/letsencrypt/live/{{ item | split(',') | first }}/fullchain.pem"
   with_items:
     - "{{ inventory_hostname }}.box.pydis.wtf"
     - "{{ certbot_domains[inventory_hostname] }}"

--- a/ansible/roles/certbot/vars/main/main.yml
+++ b/ansible/roles/certbot/vars/main/main.yml
@@ -4,9 +4,7 @@ certbot_email: "joe@jb3.dev"
 certbot_domains:
   lovelace:
     - prometheus.lovelace.box.pydis.wtf
-    - pydis.wtf
-    - "*.pydis.wtf"
-    - cloud.native.is.fun.and.easy.pydis.wtf
+    - "pydis.wtf,*.pydis.wtf,cloud.native.is.fun.and.easy.pydis.wtf"
 
 certbot_cert_users:
   lovelace:


### PR DESCRIPTION
We now can use CSV values to group different (but related) SANs into one
issued certificate.

As an example, when it was migrated in #402, certificates were
configured in such a way that certbot attempted to issue one certificate
for pydis.wtf and another for *.pydis.wtf, which is obviously not
desirable.

This restores previous behaviour to group together certificates served
from the same NGINX vhost, using some Ansible filters to ensure the
`creates` option of the task matches the certbot generated directory.