### PR TITLE
Migrate DNS to using CNAMEs

### DIFF
--- a/ansible/inventory/hosts.yaml
+++ b/ansible/inventory/hosts.yaml
@@ -8,7 +8,6 @@ all:
   children:
     netcup:
       hosts:
-        turing:
         lovelace:
     nginx:
       hosts:

--- a/ansible/roles/fail2ban/templates/jail.local.j2
+++ b/ansible/roles/fail2ban/templates/jail.local.j2
@@ -1,7 +1,7 @@
 [DEFAULT]
 ignoreip = 127.0.0.1/8 ::1 192.168.1.0/24 10.0.0.0/8
     # netcup ips
-    89.58.26.118  2a03:4000:62:ce0:2496:aeff:fe97:dea4 89.58.25.151 2a03:4000:62:ce1:943b:b2ff:fef4:d3b7
+    89.58.26.118  2a03:4000:62:ce0:2496:aeff:fe97:dea4
     # linode ips
     {{ lke_frankfurt_ipv4_addresses | join(" ") }} {{ lke_frankfurt_ipv6_addresses | join(" ") }}
 

--- a/dns/production.yaml
+++ b/dns/production.yaml
@@ -10,6 +10,7 @@ providers:
     directory: dns/zones
     default_ttl: 300
     enforce_order: true
+    split_extension: "."
   cloudflare:
     class: octodns_cloudflare.CloudflareProvider
     token: env/CLOUDFLARE_TOKEN
@@ -17,7 +18,7 @@ providers:
     pagerules: false
 
 zones:
-  '*':
+  "*":
     sources:
       - zone_config
     targets:

--- a/dns/production.yaml
+++ b/dns/production.yaml
@@ -4,6 +4,10 @@ manager:
     html:
       class: octodns.provider.plan.PlanMarkdown
 
+processors:
+  meta:
+    class: octodns.processor.meta.MetaProcessor
+
 providers:
   zone_config:
     class: octodns.provider.yaml.YamlProvider

--- a/dns/zones/pydis.wtf./box.yaml
+++ b/dns/zones/pydis.wtf./box.yaml
@@ -1,0 +1,32 @@
+---
+ldap01.box:
+  octodns:
+    cloudflare:
+      auto-ttl: true
+      proxied: false
+  ttl: 300
+  type: A
+  value: 139.162.163.212
+
+linode-lb.box:
+  octodns:
+    cloudflare:
+      auto-ttl: true
+      proxied: false
+  ttl: 300
+  type: A
+  value: 194.195.247.228
+
+lovelace.box:
+  - octodns:
+      cloudflare:
+        auto-ttl: true
+    ttl: 300
+    type: A
+    value: 89.58.26.118
+  - octodns:
+      cloudflare:
+        auto-ttl: true
+    ttl: 300
+    type: AAAA
+    value: 2a03:4000:62:ce0:2496:aeff:fe97:dea4

--- a/dns/zones/pydis.wtf./box.yaml
+++ b/dns/zones/pydis.wtf./box.yaml
@@ -1,4 +1,12 @@
 ---
+"*.lovelace.box":
+  octodns:
+    cloudflare:
+      auto-ttl: true
+  ttl: 300
+  type: CNAME
+  value: lovelace.box.pydis.wtf.
+
 ldap01.box:
   octodns:
     cloudflare:

--- a/dns/zones/pydis.wtf./root.yaml
+++ b/dns/zones/pydis.wtf./root.yaml
@@ -99,15 +99,6 @@ id:
   type: A
   value: 194.195.247.228
 
-ldap01.box:
-  octodns:
-    cloudflare:
-      auto-ttl: true
-      proxied: false
-  ttl: 300
-  type: A
-  value: 139.162.163.212
-
 loki-gateway:
   octodns:
     cloudflare:
@@ -116,20 +107,6 @@ loki-gateway:
   ttl: 300
   type: A
   value: 194.195.247.228
-
-lovelace.box:
-  - octodns:
-      cloudflare:
-        auto-ttl: true
-    ttl: 300
-    type: A
-    value: 89.58.26.118
-  - octodns:
-      cloudflare:
-        auto-ttl: true
-    ttl: 300
-    type: AAAA
-    value: 2a03:4000:62:ce0:2496:aeff:fe97:dea4
 
 metabase:
   octodns:

--- a/dns/zones/pydis.wtf./root.yaml
+++ b/dns/zones/pydis.wtf./root.yaml
@@ -48,56 +48,56 @@ alertmanager:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 bitwarden:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 cloud.native.is.fun.and.easy:
   octodns:
     cloudflare:
       auto-ttl: true
   ttl: 300
-  type: A
-  value: 89.58.25.151
+  type: CNAME
+  value: lovelace.box.pydis.wtf.
 
 ff-bot:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 files:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 89.58.26.118
+  type: CNAME
+  value: lovelace.box.pydis.wtf.
 
 grafana:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 id:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 loki-gateway:
   octodns:
@@ -105,24 +105,24 @@ loki-gateway:
       auto-ttl: true
       proxied: false
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 metabase:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 modmail:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 ops:
   octodns:
@@ -145,59 +145,54 @@ pddc.devops:
     cloudflare:
       auto-ttl: true
   ttl: 300
-  type: A
-  value: 89.58.25.151
+  type: CNAME
+  value: lovelace.box.pydis.wtf.
 
 pixels-mod:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 policy-bot:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 prometheus:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 prometheus.lovelace.box:
-  - octodns:
-      cloudflare:
-        auto-ttl: true
-    ttl: 300
-    type: A
-    value: 89.58.26.118
-  - octodns:
-      cloudflare:
-        auto-ttl: true
-    ttl: 300
-    type: AAAA
-    value: 2a03:4000:62:ce0:2496:aeff:fe97:dea4
+  octodns:
+    cloudflare:
+      auto-ttl: true
+      proxied: false
+  ttl: 300
+  type: CNAME
+  value: lovelace.box.pydis.wtf.
 
 vault:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 www:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 89.58.25.151
+  type: CNAME
+  value: lovelace.box.pydis.wtf.

--- a/dns/zones/pydis.wtf./root.yaml
+++ b/dns/zones/pydis.wtf./root.yaml
@@ -172,15 +172,6 @@ prometheus:
   type: CNAME
   value: linode-lb.box.pydis.wtf.
 
-prometheus.lovelace.box:
-  octodns:
-    cloudflare:
-      auto-ttl: true
-      proxied: false
-  ttl: 300
-  type: CNAME
-  value: lovelace.box.pydis.wtf.
-
 vault:
   octodns:
     cloudflare:

--- a/dns/zones/pythondiscord.com.yaml
+++ b/dns/zones/pythondiscord.com.yaml
@@ -1,11 +1,11 @@
 ---
-'':
+"":
   - octodns:
       cloudflare:
         proxied: true
     ttl: 300
-    type: A
-    value: 194.195.247.228
+    type: ALIAS
+    value: linode-lb.box.pydis.wtf.
 
   - octodns:
       cloudflare:
@@ -13,12 +13,12 @@
     ttl: 300
     type: MX
     values:
-    - exchange: amir.mx.cloudflare.net.
-      preference: 19
-    - exchange: linda.mx.cloudflare.net.
-      preference: 40
-    - exchange: isaac.mx.cloudflare.net.
-      preference: 65
+      - exchange: amir.mx.cloudflare.net.
+        preference: 19
+      - exchange: linda.mx.cloudflare.net.
+        preference: 40
+      - exchange: isaac.mx.cloudflare.net.
+        preference: 65
 
   - octodns:
       cloudflare:
@@ -26,10 +26,10 @@
     ttl: 300
     type: TXT
     values:
-    - google-site-verification=2-WR3alaLn7r-_pRPyYZhnh0YYYe4Bbydo32bfg4Wxo
-    - google-site-verification=cdfwmXlZDb57NUuy_1EOSrxfEYAYp_P232bOkrWVudM
-    - keybase-site-verification=PeSqpPFVIy3W-YQWurEKeawYsgbH6QUjhDvf9mN3FdU
-    - v=spf1 include:_spf.mx.cloudflare.net ~all
+      - google-site-verification=2-WR3alaLn7r-_pRPyYZhnh0YYYe4Bbydo32bfg4Wxo
+      - google-site-verification=cdfwmXlZDb57NUuy_1EOSrxfEYAYp_P232bOkrWVudM
+      - keybase-site-verification=PeSqpPFVIy3W-YQWurEKeawYsgbH6QUjhDvf9mN3FdU
+      - v=spf1 include:_spf.mx.cloudflare.net ~all
 
 6ed7202cfcfe199921d5b382e200a40e598d20c3.status:
   octodns:
@@ -52,16 +52,16 @@ alertmanager:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 bitwarden:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 blog:
   octodns:
@@ -93,7 +93,7 @@ csp:
       proxied: true
   ttl: 300
   type: AAAA
-  value: '100::'
+  value: "100::"
 
 forms:
   octodns:
@@ -108,24 +108,24 @@ forms-api:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 git:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 grafana:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 mailo._domainkey:
   octodns:
@@ -140,40 +140,40 @@ merch:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 metabase:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 modmail:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 paste:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 paypal:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 peps:
   octodns:
@@ -188,48 +188,48 @@ pixels:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 policy-bot:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 prometheus:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 quackstack:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 sentry:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 stats:
   octodns:
     cloudflare:
       proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 status:
   octodns:
@@ -242,10 +242,10 @@ status:
 welcome:
   octodns:
     cloudflare:
-       proxied: true
+      proxied: true
   ttl: 300
-  type: A
-  value: 194.195.247.228
+  type: CNAME
+  value: linode-lb.box.pydis.wtf.
 
 www:
   octodns:


### PR DESCRIPTION
- Add new config to OctoDNS to allow for zones to be split into multiple YAML
  files, this allows us to have a `box.yaml` file which stores all of our
  individual machine IPs.
- Migrate all services to referring to the hosting machine via a CNAME instead
  of a static A record, making it clearer which services are hosted where as
  well as easing any updates in future.
- Remove other remnants of Turing that were left over from #402

This PR will not auto-deploy via DNS as it deletes more than 30% of our records.