### PR TITLE
Remove redirect to discord attachment link

### DIFF
--- a/ansible/roles/nginx/templates/default_server.conf
+++ b/ansible/roles/nginx/templates/default_server.conf
@@ -21,8 +21,7 @@ server {
             "https://jchri.st/blog/apfs-sadness-on-macos-big-sur.html",
             "https://cdn.discordapp.com/attachments/675756741417369640/852688961516077086/Screenshot_2021-06-11_at_00.21.22.png",
             "https://news.ycombinator.com/",
-            "https://www.hertfordshire.gov.uk/latest/letchworth-webcam.jpg",
-            "https://media.discordapp.net/attachments/922169059175444501/952929630459924501/1svkf3xto3n61.png"
+            "https://www.hertfordshire.gov.uk/latest/letchworth-webcam.jpg"
       }
       return urls [ math.random(#urls) ]
     }


### PR DESCRIPTION
The link doesn't work anymore, so not worth keeping