### PR TITLE
Add a dns record for Jitsi

### DIFF
--- a/dns/zones/pydis.wtf.zone/root.yaml
+++ b/dns/zones/pydis.wtf.zone/root.yaml
@@ -71,6 +71,14 @@ id:
   type: CNAME
   value: linode-lb.box.pydis.wtf.
 
+jitsi:
+  octodns:
+    cloudflare:
+      auto-ttl: true
+  ttl: 300
+  type: CNAME
+  value: lovelace.box.pydis.wtf.
+
 loki-gateway:
   octodns:
     cloudflare:


### PR DESCRIPTION
We will be deploying jisti on lovelace soon, so this is needed in order to route traffic to our lovelace instance and use the service