### PR TITLE
Add documentation on how to ignore render[bot]

### DIFF
--- a/docs/docs/tooling/github-bots.md
+++ b/docs/docs/tooling/github-bots.md
@@ -40,7 +40,9 @@ receive:
 ``` sieve
 require ["envelope", "fileinto", "imap4flags"];
 
-if allof (header :is "X-GitHub-Sender" ["coveralls", "github-actions[bot]", "netlify[bot]"],
+if allof (header :is "X-GitHub-Sender" [
+              "coveralls", "github-actions[bot]", "render[bot]", "netlify[bot]"
+          ],
           address :is "from" "notifications@github.com") {
     setflag "\\seen";
     fileinto "Trash";


### PR DESCRIPTION
In the latest episode of Joe Banks' continued war against our attention,
a new bot using the push-based user notification model has spawned on
the python-discord/infra repository. Attached my diplomatic response.
