### PR TITLE
Add custom links to footer

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -8,6 +8,8 @@ repo_url: https://github.com/python-discord/infra
 repo_name: python-discord/infra
 edit_uri: edit/main/docs/docs/
 
+copyright: Python Discord
+
 # Enable markdown features
 markdown_extensions:
   - abbr
@@ -62,6 +64,8 @@ plugins:
 theme:
   # Use mkdocs-material
   name: material
+  # Partial overrides directory
+  custom_dir: overrides
   # Set the logo
   logo: assets/logo.svg
 

--- a/docs/overrides/partials/copyright.html
+++ b/docs/overrides/partials/copyright.html
@@ -1,0 +1,57 @@
+<!--
+  Copyright (c) 2016-2024 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Copyright and theme information -->
+<div class="md-copyright">
+  {% if config.copyright %}
+  <div class="md-copyright__highlight">&copy; {{ config.copyright }}</div>
+  {% endif %} {% if not config.extra.generator == false %} Made with
+  <a
+    href="https://squidfunk.github.io/mkdocs-material/"
+    target="_blank"
+    rel="noopener"
+  >
+    Material for MkDocs
+  </a>
+  {% endif %}
+</div>
+
+<div class="md-copyright pydis-other-links">
+  <a href="https://www.youtube.com/watch?v=b2F-DItXtZs">DevOps on YouTube</a>
+  <a href="https://github.com/python-discord/king-arthur/"
+    >GitHub: King Arthur</a
+  >
+  <a href="https://github.com/python-discord/infra/">GitHub: Infra</a>
+  <a href="https://github.com/orgs/python-discord/projects/17/views/4"
+    >Kanban Board</a
+  >
+</div>
+
+<style>
+  .pydis-other-links a:after {
+    content: " | ";
+  }
+
+  .pydis-other-links a:last-child:after {
+    content: "";
+  }
+</style>


### PR DESCRIPTION
Re-instates the links that were available in the sidebar on Sphinx by overriding
the copyright partial provided by mkdocs.

Closes #457