### PR TITLE
Per-user website directories

### DIFF
--- a/ansible/roles/nginx/templates/default_server.conf
+++ b/ansible/roles/nginx/templates/default_server.conf
@@ -28,4 +28,9 @@ server {
 
     return 302 $url;
   }
+
+  location ~ ^/~(.+?)(/.*)?$ {
+    alias /home/$1/public$2;
+    autoindex on;
+  }
 }

--- a/dns/zones/pydis.wtf.zone/root.yaml
+++ b/dns/zones/pydis.wtf.zone/root.yaml
@@ -4,8 +4,8 @@
       cloudflare:
         proxied: true
     ttl: 300
-    type: A
-    value: 192.0.2.0 # Reserved placeholder IPv4 address
+    type: ALIAS
+    value: lovelace.box.pydis.wtf.
 
 20220929._domainkey:
   octodns:

--- a/docs/docs/onboarding/public_folders.md
+++ b/docs/docs/onboarding/public_folders.md
@@ -1,0 +1,21 @@
+---
+description: Documentation on using the ~/public folders on lovelace
+---
+# Web-accessible `public` folders
+
+DevOps team members are automatically provided access to `lovelace`, one of our
+Debian machines. Access is granted via their LDAP account which should be
+configured with a valid SSH public key.
+
+Once you have access to the host, any files you host in your `public` folder
+(i.e. `/home/joe/public`) are made accessible via `https://pydis.wtf/~username/`.
+
+By default, an autoindex page will be returned for each folder in this directory
+allowing anyone to view file contents.
+
+If you wish to disable this or wish to display some other content at that
+location (i.e. a landing page) you can create an `index.html` file anywhere
+which will be returned to browsing users.
+
+If you require any help with setting this up please let other members of the
+DevOps team know.


### PR DESCRIPTION
Adds the necessary NGINX configuration to allow `https://pydis.wtf/~username` to
direct to a users `~/public` directory.

Additionally, updates a DNS record so that traffic for pydis.wtf passes to
lovelace instead of a holding IPv4 address. The necessary changes in Cloudflare
have already been made to allow traffic to pass past the worker if destined for
any path other than the `/` index (maintaining the quote landing page for now).

A new documentation page has been created instructing users how to setup and use
the home directories.

Closes #419