### PR TITLE
Add a role to install Jitsi.

### DIFF
--- a/ansible/group_vars/all/nftables.yml
+++ b/ansible/group_vars/all/nftables.yml
@@ -88,6 +88,20 @@ nftables_configuration: |
       iifname {{ ansible_default_ipv6.interface }} tcp dport @mail_accepted ct state new accept
   {% endif %}
   {% endif %}
+
+  {% if "jitsi" in group_names %}
+      # Ports needed by Jitsi
+      define jitsi_tcp_ports = {5349}
+      define jitsi_udp_ports = {3478, 10000}
+
+      iifname {{ ansible_default_ipv4.interface }} tcp dport $jitsi_tcp_ports ct state new accept
+      iifname {{ ansible_default_ipv4.interface }} udp dport $jitsi_udp_ports ct state new accept
+  {% if ansible_default_ipv6 is defined %}
+      iifname {{ ansible_default_ipv6.interface }} tcp dport $jitsi_tcp_ports ct state new accept
+      iifname {{ ansible_default_ipv6.interface }} udp dport $jitsi_udp_ports ct state new accept
+  {% endif %}
+
+  {% endif %}
     }
 
     chain forward {

--- a/ansible/inventory/hosts.yaml
+++ b/ansible/inventory/hosts.yaml
@@ -24,5 +24,8 @@ all:
     mail:
       hosts:
         lovelace:
+    jitsi:
+      hosts:
+        lovelace:
   vars:
     wireguard_port: 46850

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -48,3 +48,8 @@
   hosts: ldap
   roles:
     - ldap
+
+- name: Deploy Jitsi
+  hosts: jitsi
+  roles:
+    - jitsi

--- a/ansible/roles/jitsi/README.md
+++ b/ansible/roles/jitsi/README.md
@@ -1,0 +1,3 @@
+# Role "jitsi"
+
+Install Jitsi Meet on target hosts.

--- a/ansible/roles/jitsi/handlers/main.yml
+++ b/ansible/roles/jitsi/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Restart the Jitsi video bridge service
+  service:
+    name: jitsi-videobridge2
+    state: restarted
+
+- name: Restart the Jitsi jicofo service
+  service:
+    name: jicofo
+    state: restarted
+
+- name: Restart the Jitsi prosody service
+  service:
+    name: prosody
+    state: restarted

--- a/ansible/roles/jitsi/meta/main.yml
+++ b/ansible/roles/jitsi/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - nftables
+  - nginx

--- a/ansible/roles/jitsi/tasks/main.yml
+++ b/ansible/roles/jitsi/tasks/main.yml
@@ -1,0 +1,101 @@
+---
+- name: Download and add Prosody Debian packages key
+  ansible.builtin.get_url:
+    url: https://prosody.im/files/prosody-debian-packages.key
+    dest: /etc/apt/keyrings/prosody-debian-packages.key
+    mode: '0644'
+  tags:
+    - role::jitsi
+
+- name: Add Prosody repository to sources list
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by=/etc/apt/keyrings/prosody-debian-packages.key] http://packages.prosody.im/debian {{ ansible_distribution_release }} main"
+    filename: prosody-debian-packages
+  tags:
+    - role::jitsi
+
+- name: Install lua5.2
+  ansible.builtin.apt:
+    name: lua5.2
+    state: present
+  tags:
+    - role::jitsi
+
+
+- name: Fetch Jitsi GPG key
+  ansible.builtin.get_url:
+    url: https://download.jitsi.org/jitsi-key.gpg.key
+    dest: /tmp/jitsi-key.gpg.key
+    mode: "u=rw,g=r,o=r"
+  tags:
+    - role::jitsi
+
+- name: Convert GPG key to keyring format
+  ansible.builtin.command:
+    cmd: gpg --dearmor -o /etc/apt/keyrings/jitsi-keyring.gpg /tmp/jitsi-key.gpg.key
+    creates: /etc/apt/keyrings/jitsi-keyring.gpg
+  tags:
+    - role::jitsi
+
+- name: Clean up temporary GPG key file
+  ansible.builtin.file:
+    path: /tmp/jitsi-key.gpg.key
+    state: absent
+  tags:
+    - role::jitsi
+
+- name: Add Jitsi repository to sources list
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by=/etc/apt/keyrings/jitsi-keyring.gpg] https://download.jitsi.org stable/"
+    filename: jitsi-stable
+  tags:
+    - role::jitsi
+
+- name: Preconfigure debconf settings for Jitsi
+  debconf:
+    name: "{{ item.name }}"
+    question: "{{ item.question }}"
+    value: "{{ item.value }}"
+    vtype: "{{ item.vtype }}"
+  loop: "{{ jitsi_debconf_questions }}"
+  tags:
+    - role::jitsi
+
+
+- name: Install Jitsi
+  ansible.builtin.apt:
+    name: jitsi-meet
+    state: present
+  tags:
+    - role::jitsi
+
+- name: Activate the jitsi server block
+  ansible.builtin.file:
+    src: /etc/nginx/sites-available/jitsi.pydis.wtf.conf
+    path: /etc/nginx/sites-enabled/jitsi.pydis.wtf.conf
+    state: link
+  tags:
+    - role::jitsi
+  notify:
+    - Reload the nginx service
+
+# Without this, all clients won't be able to connect to the video bridge.
+# Looking at /var/logs/prosody/prosody.logs, we see the "sslv3 alert certificate unknown" error
+# Solution was found on the Jitsi forum
+# https://community.jitsi.org/t/ssl-handshake-error-sslv3-alert-certificate-unknown/41245
+
+- name: Disable Video Bridge certificate verification
+  lineinfile:
+    dest: /etc/jitsi/videobridge/sip-communicator.properties
+    line: org.jitsi.videobridge.xmpp.user.shard.DISABLE_CERTIFICATE_VERIFICATION=true
+    state: present
+    create: false
+    owner: jvb
+    group: jitsi
+
+  notify:
+    - Restart the Jitsi video bridge service
+    - Restart the Jitsi prosody service
+    - Restart the Jitsi jicofo service
+  tags:
+    - role::jitsi

--- a/ansible/roles/jitsi/vars/main.yml
+++ b/ansible/roles/jitsi/vars/main.yml
@@ -1,0 +1,29 @@
+---
+
+
+jitsi_debconf_questions:
+  - name: 'jitsi-meet-web-config'
+    question: 'jitsi-meet/cert-choice'
+    value: 'I want to use my own certificate'
+    vtype: 'select'
+
+  - name: 'jitsi-meet-web-config'
+    question: 'jitsi-meet/cert-path-crt'
+    value: '/etc/letsencrypt/live/pydis.wtf/fullchain.pem'
+    vtype: 'string'
+
+  - name: 'jitsi-meet-web-config'
+    question: 'jitsi-meet/cert-path-key'
+    value: '/etc/letsencrypt/live/pydis.wtf/privkey.pem'
+    vtype: 'string'
+
+  - name: 'jitsi-meet-web-config'
+    question: 'jitsi-meet/jaas-choice'
+    value: 'false'
+    vtype: 'boolean'
+
+
+  - name: 'jitsi-videobridge2'
+    question: 'jitsi-videobridge/jvb-hostname'
+    value: 'jitsi.pydis.wtf'
+    vtype: 'string'


### PR DESCRIPTION
Since the beginning of time, we have relied on dennis services to host our very productive devops meetings, thanks Dennis.

However, a new dawn shines its light on the Pydis Devops team, a dawn where we have our own service to host our invaluable meetings.

This PR adds the role that configures and install jitsi to run on `jitsi.pydis.wtf`.

