### PR TITLE
Automatically configure default IMAP folders

### DIFF
--- a/ansible/roles/dovecot/tasks/main.yml
+++ b/ansible/roles/dovecot/tasks/main.yml
@@ -77,6 +77,8 @@
       path: 10-auth.conf
     - template: 10-ssl.conf.j2
       path: 10-ssl.conf
+    - template: 15-mailboxes.conf.j2
+      path: 15-mailboxes.conf
     - template: auth-ldap.conf.ext.j2
       path: auth-ldap.conf.ext
   tags:

--- a/ansible/roles/dovecot/templates/configs/15-mailboxes.conf.j2
+++ b/ansible/roles/dovecot/templates/configs/15-mailboxes.conf.j2
@@ -49,21 +49,29 @@
 # NOTE: Assumes "namespace inbox" has been defined in 10-mail.conf.
 namespace inbox {
   # These mailboxes are widely used and could perhaps be created automatically:
+  mailbox Archive {
+    special_use = \Archive
+    auto = subscribe
+  }
   mailbox Drafts {
     special_use = \Drafts
+    auto = subscribe
   }
   mailbox Junk {
     special_use = \Junk
+    auto = subscribe
   }
   mailbox Trash {
     autoexpunge = 60d
     special_use = \Trash
+    auto = subscribe
   }
 
   # For \Sent mailboxes there are two widely used names. We'll mark both of
   # them as \Sent. User typically deletes one of them if duplicates are created.
   mailbox Sent {
     special_use = \Sent
+    auto = subscribe
   }
   mailbox "Sent Messages" {
     special_use = \Sent

--- a/ansible/roles/dovecot/templates/configs/15-mailboxes.conf.j2
+++ b/ansible/roles/dovecot/templates/configs/15-mailboxes.conf.j2
@@ -13,11 +13,11 @@
 #   implicitly when it is first accessed. The user can also be automatically
 #   subscribed to the mailbox after creation. The following values are
 #   defined for this setting:
-# 
+#
 #     no        - Never created automatically.
 #     create    - Automatically created, but no automatic subscription.
 #     subscribe - Automatically created and subscribed.
-#  
+#
 # special_use:
 #   A space-separated list of SPECIAL-USE flags (RFC 6154) to use for the
 #   mailbox. There are no validity checks, so you could specify anything

--- a/ansible/roles/dovecot/templates/configs/15-mailboxes.conf.j2
+++ b/ansible/roles/dovecot/templates/configs/15-mailboxes.conf.j2
@@ -1,0 +1,89 @@
+# Ansible managed
+
+##
+## Mailbox definitions
+##
+
+# Each mailbox is specified in a separate mailbox section. The section name
+# specifies the mailbox name. If it has spaces, you can put the name
+# "in quotes". These sections can contain the following mailbox settings:
+#
+# auto:
+#   Indicates whether the mailbox with this name is automatically created
+#   implicitly when it is first accessed. The user can also be automatically
+#   subscribed to the mailbox after creation. The following values are
+#   defined for this setting:
+# 
+#     no        - Never created automatically.
+#     create    - Automatically created, but no automatic subscription.
+#     subscribe - Automatically created and subscribed.
+#  
+# special_use:
+#   A space-separated list of SPECIAL-USE flags (RFC 6154) to use for the
+#   mailbox. There are no validity checks, so you could specify anything
+#   you want in here, but it's not a good idea to use flags other than the
+#   standard ones specified in the RFC:
+#
+#     \All       - This (virtual) mailbox presents all messages in the
+#                  user's message store.
+#     \Archive   - This mailbox is used to archive messages.
+#     \Drafts    - This mailbox is used to hold draft messages.
+#     \Flagged   - This (virtual) mailbox presents all messages in the
+#                  user's message store marked with the IMAP \Flagged flag.
+#     \Important - This (virtual) mailbox presents all messages in the
+#                  user's message store deemed important to user.
+#     \Junk      - This mailbox is where messages deemed to be junk mail
+#                  are held.
+#     \Sent      - This mailbox is used to hold copies of messages that
+#                  have been sent.
+#     \Trash     - This mailbox is used to hold messages that have been
+#                  deleted.
+#
+# comment:
+#   Defines a default comment or note associated with the mailbox. This
+#   value is accessible through the IMAP METADATA mailbox entries
+#   "/shared/comment" and "/private/comment". Users with sufficient
+#   privileges can override the default value for entries with a custom
+#   value.
+
+# NOTE: Assumes "namespace inbox" has been defined in 10-mail.conf.
+namespace inbox {
+  # These mailboxes are widely used and could perhaps be created automatically:
+  mailbox Drafts {
+    special_use = \Drafts
+  }
+  mailbox Junk {
+    special_use = \Junk
+  }
+  mailbox Trash {
+    autoexpunge = 60d
+    special_use = \Trash
+  }
+
+  # For \Sent mailboxes there are two widely used names. We'll mark both of
+  # them as \Sent. User typically deletes one of them if duplicates are created.
+  mailbox Sent {
+    special_use = \Sent
+  }
+  mailbox "Sent Messages" {
+    special_use = \Sent
+  }
+
+  # If you have a virtual "All messages" mailbox:
+  #mailbox virtual/All {
+  #  special_use = \All
+  #  comment = All my messages
+  #}
+
+  # If you have a virtual "Flagged" mailbox:
+  #mailbox virtual/Flagged {
+  #  special_use = \Flagged
+  #  comment = All my flagged messages
+  #}
+
+  # If you have a virtual "Important" mailbox:
+  #mailbox virtual/Important {
+  #  special_use = \Important
+  #  comment = All my important messages
+  #}
+}


### PR DESCRIPTION
Additionally, automatically expunge (delete) mails older than 60 days
from the Trash folder.
