### PR TITLE
Add spamassassin

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -24,6 +24,7 @@
     - opendmarc
     - sasl
     - dovecot
+    - spamassassin
     - postfix
 
 - name: Deploy our monitoring stack

--- a/ansible/roles/dovecot/files/spamc-learn-ham.sh
+++ b/ansible/roles/dovecot/files/spamc-learn-ham.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Ansible managed
+
+exec /usr/bin/spamc --learntype=ham

--- a/ansible/roles/dovecot/files/spamc-learn-ham.sh
+++ b/ansible/roles/dovecot/files/spamc-learn-ham.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # Ansible managed
 
-exec /usr/bin/spamc --learntype=ham
+exec /usr/bin/spamc --learntype=ham -u debian-spamd

--- a/ansible/roles/dovecot/files/spamc-learn-spam.sh
+++ b/ansible/roles/dovecot/files/spamc-learn-spam.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Ansible managed
+
+exec /usr/bin/spamc --learntype=spam

--- a/ansible/roles/dovecot/files/spamc-learn-spam.sh
+++ b/ansible/roles/dovecot/files/spamc-learn-spam.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # Ansible managed
 
-exec /usr/bin/spamc --learntype=spam
+exec /usr/bin/spamc --learntype=spam -u debian-spamd

--- a/ansible/roles/dovecot/handlers/main.yml
+++ b/ansible/roles/dovecot/handlers/main.yml
@@ -8,3 +8,7 @@
   service:
     name: dovecot
     state: restarted
+
+- name: Recompile spam-to-folder sieve script
+  command: /usr/bin/sievec /etc/dovecot/sieve-after/spam-to-folder.sieve
+  changed_when: true

--- a/ansible/roles/dovecot/handlers/main.yml
+++ b/ansible/roles/dovecot/handlers/main.yml
@@ -12,3 +12,11 @@
 - name: Recompile spam-to-folder sieve script
   command: /usr/bin/sievec /etc/dovecot/sieve-after/spam-to-folder.sieve
   changed_when: true
+
+- name: Recompile learn-spam sieve script
+  command: /usr/bin/sievec /etc/dovecot/sieve/learn-spam.sieve
+  changed_when: true
+
+- name: Recompile learn-ham sieve script
+  command: /usr/bin/sievec /etc/dovecot/sieve/learn-ham.sieve
+  changed_when: true

--- a/ansible/roles/dovecot/tasks/main.yml
+++ b/ansible/roles/dovecot/tasks/main.yml
@@ -51,6 +51,39 @@
   notify:
     - Reload Dovecot
 
+- name: Create sieve-after directory
+  file:
+    state: directory
+    path: /etc/dovecot/sieve-after
+    owner: vmail
+    group: vmail
+    mode: "0755"
+  tags:
+    - role::dovecot
+
+- name: Template spam-to-folder sieve script
+  template:
+    src: spam-to-folder.sieve.j2
+    dest: /etc/dovecot/sieve-after/spam-to-folder.sieve
+    owner: vmail
+    group: vmail
+    mode: 0444
+  notify:
+    - Recompile spam-to-folder sieve script
+  tags:
+    - role::dovecot
+
+- name: Set up sieve configuration for dovecot
+  lineinfile:
+    path: /etc/dovecot/conf.d/90-sieve.conf
+    regexp: "sieve_after ="
+    line: "  sieve_after = /etc/dovecot/sieve-after  # (ansible managed)"
+    state: present
+  notify:
+    - Reload Dovecot
+  tags:
+    - role::dovecot
+
 - name: Template Dovecot LDAP config
   template:
     src: dovecot-ldap.conf.ext.j2

--- a/ansible/roles/dovecot/tasks/main.yml
+++ b/ansible/roles/dovecot/tasks/main.yml
@@ -51,13 +51,16 @@
   notify:
     - Reload Dovecot
 
-- name: Create sieve-after directory
+- name: Create sieve directories
   file:
     state: directory
-    path: /etc/dovecot/sieve-after
+    path: "/etc/dovecot/{{ item }}"
     owner: vmail
     group: vmail
     mode: "0755"
+  loop:
+    - sieve
+    - sieve-after
   tags:
     - role::dovecot
 
@@ -67,7 +70,7 @@
     dest: /etc/dovecot/sieve-after/spam-to-folder.sieve
     owner: vmail
     group: vmail
-    mode: 0444
+    mode: "0444"
   notify:
     - Recompile spam-to-folder sieve script
   tags:
@@ -78,6 +81,72 @@
     path: /etc/dovecot/conf.d/90-sieve.conf
     regexp: "sieve_after ="
     line: "  sieve_after = /etc/dovecot/sieve-after  # (ansible managed)"
+    state: present
+  notify:
+    - Reload Dovecot
+  tags:
+    - role::dovecot
+
+- name: Create dovecot spam & ham sieve scripts
+  template:
+    src: "{{ item }}.j2"
+    dest: /etc/dovecot/sieve/{{ item }}
+    owner: vmail
+    group: vmail
+    mode: "0444"
+  with_items:
+    - learn-spam.sieve
+    - learn-ham.sieve
+  notify:
+    - Restart Dovecot
+    - Recompile dovecot learn-spam sieve script
+    - Recompile dovecot learn-ham sieve script
+  tags:
+    - role::dovecot
+
+- name: Create dovecot sieve pipe bin dir
+  file:
+    path: "{{ dovecot_sieve_pipe_bin_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0555"
+  tags:
+    - role::dovecot
+
+- name: Create dovecot spam & ham shell scripts
+  copy:
+    src: "{{ item }}"
+    dest: "{{ dovecot_sieve_pipe_bin_dir }}/{{ item }}"
+    owner: vmail
+    group: vmail
+    mode: "0500"
+  with_items:
+    - spamc-learn-ham.sh
+    - spamc-learn-spam.sh
+  tags:
+    - role::dovecot
+
+- name: Enable dovecot spamc learning integration
+  blockinfile:
+    path: /etc/dovecot/conf.d/90-sieve.conf
+    insertbefore: "^}$"
+    content: |2
+        # From elsewhere to Junk folder
+        imapsieve_mailbox1_name = Junk
+        imapsieve_mailbox1_causes = COPY
+        imapsieve_mailbox1_before = file:/etc/dovecot/sieve/learn-spam.sieve
+
+        # From Junk folder to elsewhere
+        imapsieve_mailbox2_name = *
+        imapsieve_mailbox2_from = Junk
+        imapsieve_mailbox2_causes = COPY
+        imapsieve_mailbox2_before = file:/etc/dovecot/sieve/learn-ham.sieve
+
+        sieve_pipe_bin_dir = {{ dovecot_sieve_pipe_bin_dir }}
+        sieve_global_extensions = +vnd.dovecot.pipe
+        sieve_plugins = sieve_imapsieve sieve_extprograms
+    marker: "  # {mark} spam & ham autolearning (ansible managed)"
     state: present
   notify:
     - Reload Dovecot

--- a/ansible/roles/dovecot/tasks/main.yml
+++ b/ansible/roles/dovecot/tasks/main.yml
@@ -146,6 +146,7 @@
         sieve_pipe_bin_dir = {{ dovecot_sieve_pipe_bin_dir }}
         sieve_global_extensions = +vnd.dovecot.pipe
         sieve_plugins = sieve_imapsieve sieve_extprograms
+        imapsieve_url = sieve://127.0.0.1:4190
     marker: "  # {mark} spam & ham autolearning (ansible managed)"
     state: present
   notify:
@@ -179,6 +180,7 @@
     - 10-ssl.conf
     - 15-mailboxes.conf
     - 20-lmtp.conf
+    - 20-imap.conf
     - auth-ldap.conf.ext
   tags:
     - role::dovecot

--- a/ansible/roles/dovecot/templates/configs/10-mail.conf.j2
+++ b/ansible/roles/dovecot/templates/configs/10-mail.conf.j2
@@ -219,7 +219,7 @@ mail_privileged_group = mail
 
 # Space separated list of plugins to load for all services. Plugins specific to
 # IMAP, LDA, etc. are added to this list in their own .conf files.
-mail_plugins = welcome
+mail_plugins = welcome notify
 
 ##
 ## Mailbox handling optimizations

--- a/ansible/roles/dovecot/templates/configs/20-imap.conf.j2
+++ b/ansible/roles/dovecot/templates/configs/20-imap.conf.j2
@@ -1,0 +1,105 @@
+# Ansible Managed
+
+##
+## IMAP specific settings
+##
+
+# If nothing happens for this long while client is IDLEing, move the connection
+# to imap-hibernate process and close the old imap process. This saves memory,
+# because connections use very little memory in imap-hibernate process. The
+# downside is that recreating the imap process back uses some resources.
+#imap_hibernate_timeout = 0
+
+# Maximum IMAP command line length. Some clients generate very long command
+# lines with huge mailboxes, so you may need to raise this if you get
+# "Too long argument" or "IMAP command line too large" errors often.
+#imap_max_line_length = 64k
+
+# IMAP logout format string:
+#  %i - total number of bytes read from client
+#  %o - total number of bytes sent to client
+#  %{fetch_hdr_count} - Number of mails with mail header data sent to client
+#  %{fetch_hdr_bytes} - Number of bytes with mail header data sent to client
+#  %{fetch_body_count} - Number of mails with mail body data sent to client
+#  %{fetch_body_bytes} - Number of bytes with mail body data sent to client
+#  %{deleted} - Number of mails where client added \Deleted flag
+#  %{expunged} - Number of mails that client expunged, which does not
+#                include automatically expunged mails
+#  %{autoexpunged} - Number of mails that were automatically expunged after
+#                    client disconnected
+#  %{trashed} - Number of mails that client copied/moved to the
+#               special_use=\Trash mailbox.
+#  %{appended} - Number of mails saved during the session
+#imap_logout_format = in=%i out=%o deleted=%{deleted} expunged=%{expunged} \
+#  trashed=%{trashed} hdr_count=%{fetch_hdr_count} \
+#  hdr_bytes=%{fetch_hdr_bytes} body_count=%{fetch_body_count} \
+#  body_bytes=%{fetch_body_bytes}
+
+# Override the IMAP CAPABILITY response. If the value begins with '+',
+# add the given capabilities on top of the defaults (e.g. +XFOO XBAR).
+#imap_capability =
+
+# How long to wait between "OK Still here" notifications when client is
+# IDLEing.
+#imap_idle_notify_interval = 2 mins
+
+# ID field names and values to send to clients. Using * as the value makes
+# Dovecot use the default value. The following fields have default values
+# currently: name, version, os, os-version, support-url, support-email,
+# revision.
+#imap_id_send =
+
+# ID fields sent by client to log. * means everything.
+#imap_id_log =
+
+# Workarounds for various client bugs:
+#   delay-newmail:
+#     Send EXISTS/RECENT new mail notifications only when replying to NOOP
+#     and CHECK commands. Some clients ignore them otherwise, for example OSX
+#     Mail (<v2.1). Outlook Express breaks more badly though, without this it
+#     may show user "Message no longer in server" errors. Note that OE6 still
+#     breaks even with this workaround if synchronization is set to
+#     "Headers Only".
+#   tb-extra-mailbox-sep:
+#     Thunderbird gets somehow confused with LAYOUT=fs (mbox and dbox) and
+#     adds extra '/' suffixes to mailbox names. This option causes Dovecot to
+#     ignore the extra '/' instead of treating it as invalid mailbox name.
+#   tb-lsub-flags:
+#     Show \Noselect flags for LSUB replies with LAYOUT=fs (e.g. mbox).
+#     This makes Thunderbird realize they aren't selectable and show them
+#     greyed out, instead of only later giving "not selectable" popup error.
+#
+# The list is space-separated.
+#imap_client_workarounds =
+
+# Host allowed in URLAUTH URLs sent by client. "*" allows all.
+#imap_urlauth_host =
+
+# Enable IMAP LITERAL- extension (replaces LITERAL+)
+#imap_literal_minus = no
+
+# What happens when FETCH fails due to some internal error:
+#   disconnect-immediately:
+#     The FETCH is aborted immediately and the IMAP client is disconnected.
+#   disconnect-after:
+#     The FETCH runs for all the requested mails returning as much data as
+#     possible. The client is finally disconnected without a tagged reply.
+#   no-after:
+#     Same as disconnect-after, but tagged NO reply is sent instead of
+#     disconnecting the client. If the client attempts to FETCH the same failed
+#     mail more than once, the client is disconnected. This is to avoid clients
+#     from going into infinite loops trying to FETCH a broken mail.
+#imap_fetch_failure = disconnect-immediately
+
+mail_attribute_dict = file:~/mail/dovecot-attributes
+
+protocol imap {
+  # Space separated list of plugins to load (default is global mail_plugins).
+  mail_plugins = $mail_plugins imap_sieve
+
+  imap_metadata = yes
+
+  # Maximum number of IMAP connections allowed for a user from each IP address.
+  # NOTE: The username is compared case-sensitively.
+  #mail_max_userip_connections = 10
+}

--- a/ansible/roles/dovecot/templates/configs/auth-ldap.conf.ext.j2
+++ b/ansible/roles/dovecot/templates/configs/auth-ldap.conf.ext.j2
@@ -13,5 +13,5 @@ passdb {
 
 userdb {
   driver = static
-  args = uid=vmail gid=vmail home=/var/vmail/%u mail=maildir:~/mail sieve=/home/%u/sieve
+  args = uid=vmail gid=vmail home=/var/vmail/%u mail=maildir:~/mail sieve=/home/%u/sieve sieve_user_log=/var/mail/%u/sieve.log
 }

--- a/ansible/roles/dovecot/templates/configs/auth-ldap.conf.ext.j2
+++ b/ansible/roles/dovecot/templates/configs/auth-ldap.conf.ext.j2
@@ -13,5 +13,5 @@ passdb {
 
 userdb {
   driver = static
-  args = uid=vmail gid=vmail home=/var/vmail/%u mail=maildir:~/mail sieve=/home/%u/sieve sieve_user_log=/var/mail/%u/sieve.log
+  args = uid=vmail gid=vmail home=/var/vmail/%u mail=maildir:~/mail sieve=/home/%u/sieve sieve_user_log=/var/vmail/%u/sieve.log
 }

--- a/ansible/roles/dovecot/templates/learn-ham.sieve.j2
+++ b/ansible/roles/dovecot/templates/learn-ham.sieve.j2
@@ -1,0 +1,10 @@
+# Ansible managed
+
+require ["vnd.dovecot.pipe", "copy", "imapsieve", "variables"];
+
+# Ignore e-mails being moved into Trash for Ham learning
+if string "${mailbox}" "Trash" {
+  stop;
+}
+
+pipe :copy "spamc-learn-ham.sh";

--- a/ansible/roles/dovecot/templates/learn-spam.sieve.j2
+++ b/ansible/roles/dovecot/templates/learn-spam.sieve.j2
@@ -1,0 +1,5 @@
+# Ansible managed
+
+require ["vnd.dovecot.pipe", "copy", "imapsieve"];
+
+pipe :copy "spamc-learn-spam.sh";

--- a/ansible/roles/dovecot/templates/spam-to-folder.sieve.j2
+++ b/ansible/roles/dovecot/templates/spam-to-folder.sieve.j2
@@ -1,0 +1,8 @@
+# Ansible managed
+
+require ["fileinto"];
+
+if header :contains "X-Spam" "Yes" {
+  fileinto "Junk";
+  stop;
+}

--- a/ansible/roles/dovecot/vars/main/main.yml
+++ b/ansible/roles/dovecot/vars/main/main.yml
@@ -4,3 +4,4 @@ dovecot_ldap_user: "uid=dovecot,cn=users,cn=accounts,dc=box,dc=pydis,dc=wtf"
 dovecot_ldap_password: "{{ vault_dovecot_ldap_password }}"
 dovecot_ldap_tls_ca: "/etc/ipa/ca.crt"
 dovecot_vmail_uid: "5000"
+dovecot_sieve_pipe_bin_dir: /usr/lib/dovecot/sieve

--- a/ansible/roles/postfix/tasks/main.yml
+++ b/ansible/roles/postfix/tasks/main.yml
@@ -176,7 +176,7 @@
 
       # spamassassin filtering
       spamassassin unix -     n       n       -       -       pipe
-        user=spamd argv=/usr/bin/spamc -f -e
+        user=debian-spamd argv=/usr/bin/spamc -f -e
         /usr/sbin/sendmail -oi -f ${sender} ${recipient}
 
       # authenticated submission cleanup

--- a/ansible/roles/postfix/tasks/main.yml
+++ b/ansible/roles/postfix/tasks/main.yml
@@ -134,6 +134,16 @@
   tags:
     - role::postfix
 
+- name: Pass inbound mail through spamassassin content filter
+  lineinfile:
+    path: /etc/postfix/master.cf
+    insertafter: "smtp      inet  n       -       y       -       -       smtpd"
+    line: " -o content_filter=spamassassin"
+  tags:
+    - role::postfix
+  notify:
+    - Restart postfix
+
 - name: Add custom services to master.cf
   blockinfile:
     path: /etc/postfix/master.cf
@@ -163,6 +173,11 @@
         -o smtpd_sasl_type=dovecot
         -o smtpd_sasl_path=private/auth
         -o cleanup_service_name=authcleanup
+
+      # spamassassin filtering
+      spamassassin unix -     n       n       -       -       pipe
+        user=spamd argv=/usr/bin/spamc -f -e
+        /usr/sbin/sendmail -oi -f ${sender} ${recipient}
 
       # authenticated submission cleanup
       authcleanup unix  n       -       y       -       0       cleanup

--- a/ansible/roles/spamassassin/handlers/main.yml
+++ b/ansible/roles/spamassassin/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Restart spamd
+  service:
+    name: spamd
+    state: restarted
+
+- name: Reload spamd
+  service:
+    name: spamd
+    state: reloaded

--- a/ansible/roles/spamassassin/tasks/main.yml
+++ b/ansible/roles/spamassassin/tasks/main.yml
@@ -30,7 +30,7 @@
     - key: AHOME
       value: "/var/log/spamassassin/"
     - key: OPTIONS
-      value: "--create-prefs --max-children 5 --username spamd --helper-home-dir /var/spamd/ -s /var/spamd/spamd.log"
+      value: "--create-prefs --max-children 5 --username spamd --helper-home-dir /var/spamd/ -s /var/spamd/spamd.log --allow-tell"
     - key: CRON
       value: "1"
   tags:

--- a/ansible/roles/spamassassin/tasks/main.yml
+++ b/ansible/roles/spamassassin/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+- name: Install spamassassin packages
+  package:
+    state: present
+    name:
+      - spamassassin
+      - spamc
+  tags:
+    - role::spamassassin
+
+- name: Create spamd user
+  user:
+    name: spamd
+    home: /var/spamd
+    comment: "SpamAssassin user"
+  tags:
+    - role::spamassassin
+
+- name: Update spamd defaults
+  lineinfile:
+    path: /etc/default/spamd
+    regexp: '^{{ item[''key''] }}="'
+    line: '{{ item["key"] }}="{{ item["value"] }}"'
+    mode: "0644"
+    owner: root
+    group: root
+  loop:
+    - key: ENABLED
+      value: "1"
+    - key: AHOME
+      value: "/var/log/spamassassin/"
+    - key: OPTIONS
+      value: "--create-prefs --max-children 5 --username spamd --helper-home-dir /var/spamd/ -s /var/spamd/spamd.log"
+    - key: CRON
+      value: "1"
+  tags:
+    - role::spamassassin
+  notify:
+    - Restart spamd
+
+- name: Template local.cf spamassassin configuation file
+  template:
+    src: local.cf.j2
+    dest: /etc/spamassassin/local.cf
+    group: root
+    owner: root
+    mode: "0644"
+  tags:
+    - role::spamassassin
+  notify:
+    - Reload spamd

--- a/ansible/roles/spamassassin/tasks/main.yml
+++ b/ansible/roles/spamassassin/tasks/main.yml
@@ -8,14 +8,6 @@
   tags:
     - role::spamassassin
 
-- name: Create spamd user
-  user:
-    name: spamd
-    home: /var/spamd
-    comment: "SpamAssassin user"
-  tags:
-    - role::spamassassin
-
 - name: Update spamd defaults
   lineinfile:
     path: /etc/default/spamd
@@ -30,7 +22,7 @@
     - key: AHOME
       value: "/var/log/spamassassin/"
     - key: OPTIONS
-      value: "--create-prefs --max-children 5 --username spamd --helper-home-dir /var/spamd/ -s /var/spamd/spamd.log --allow-tell"
+      value: "--create-prefs --max-children 5 --username debian-spamd --helper-home-dir /var/lib/spamassassin/ -s /var/log/spamd.log --allow-tell"
     - key: CRON
       value: "1"
   tags:

--- a/ansible/roles/spamassassin/templates/local.cf.j2
+++ b/ansible/roles/spamassassin/templates/local.cf.j2
@@ -1,0 +1,114 @@
+# Managed by Ansible
+
+# This is the right place to customize your installation of SpamAssassin.
+#
+# See 'perldoc Mail::SpamAssassin::Conf' for details of what can be
+# tweaked.
+#
+# Only a small subset of options are listed below
+#
+###########################################################################
+
+#    A 'contact address' users should contact for more info. (replaces
+#    _CONTACTADDRESS_ in the report template)
+report_contact {{ spamassassin_contact_email }}
+
+
+#   Add *****SPAM***** to the Subject header of spam e-mails
+#
+rewrite_header Subject *****SPAM*****
+
+
+#   Save spam messages as a message/rfc822 MIME attachment instead of
+#   modifying the original message (0: off, 2: use text/plain instead)
+#
+# report_safe 1
+
+
+#   Set which networks or hosts are considered 'trusted' by your mail
+#   server (i.e. not spammers)
+#
+# trusted_networks 212.17.35.
+
+
+#   Set file-locking method (flock is not safe over NFS, but is faster)
+#
+# lock_method flock
+
+
+#   Set the threshold at which a message is considered spam (default: 5.0)
+#
+# required_score 5.0
+
+
+#   Use Bayesian classifier (default: 1)
+#
+use_bayes 1
+
+
+#   Bayesian classifier auto-learning (default: 1)
+#
+bayes_auto_learn 1
+
+
+#   Set headers which may provide inappropriate cues to the Bayesian
+#   classifier
+#
+# bayes_ignore_header X-Bogosity
+# bayes_ignore_header X-Spam-Flag
+# bayes_ignore_header X-Spam-Status
+
+
+#   Whether to decode non- UTF-8 and non-ASCII textual parts and recode
+#   them to UTF-8 before the text is given over to rules processing.
+#
+# normalize_charset 1
+
+#   Textual body scan limit    (default: 50000)
+#
+#   Amount of data per email text/* mimepart, that will be run through body
+#   rules.  This enables safer and faster scanning of large messages,
+#   perhaps having very large textual attachments.  There should be no need
+#   to change this well tested default.
+#
+# body_part_scan_size 50000
+
+#   Textual rawbody data scan limit    (default: 500000)
+#
+#   Amount of data per email text/* mimepart, that will be run through
+#   rawbody rules.
+#
+# rawbody_part_scan_size 500000
+
+#   Some shortcircuiting, if the plugin is enabled
+#
+ifplugin Mail::SpamAssassin::Plugin::Shortcircuit
+#
+#   default: strongly-welcomelisted mails are *really* welcomelisted now, if
+#   the shortcircuiting plugin is active, causing early exit to save CPU
+#   load.  Uncomment to turn this on
+#
+#   SpamAssassin tries hard not to launch DNS queries before priority -100.
+#   If you want to shortcircuit without launching unneeded queries, make
+#   sure such rule priority is below -100. These examples are already:
+#
+# shortcircuit USER_IN_WELCOMELIST       on
+# shortcircuit USER_IN_DEF_WELCOMELIST   on
+# shortcircuit USER_IN_ALL_SPAM_TO     on
+
+#   the opposite; blocklisted mails can also save CPU
+#
+# shortcircuit USER_IN_BLOCKLIST       on
+# shortcircuit USER_IN_BLOCKLIST_TO    on
+
+#   if you have taken the time to correctly specify your "trusted_networks",
+#   this is another good way to save CPU
+#
+# shortcircuit ALL_TRUSTED             on
+
+#   and a well-trained bayes DB can save running rules, too
+#
+# shortcircuit BAYES_99                spam
+# shortcircuit BAYES_00                ham
+
+endif # Mail::SpamAssassin::Plugin::Shortcircuit

--- a/ansible/roles/spamassassin/vars/main.yml
+++ b/ansible/roles/spamassassin/vars/main.yml
@@ -1,0 +1,2 @@
+---
+spamassassin_contact_email: "devops@pydis.wtf"


### PR DESCRIPTION
Adds spamassassin to inbound mail passing through the PyDis mailserver.

This adds a variety of headers which can be used by end user email clients or by
Sieve to filter mail according to the determined importance.