### PR TITLE
Stop installing libsasl2-modules-ldap

### DIFF
--- a/ansible/roles/jitsi/tasks/ldap_auth.yml
+++ b/ansible/roles/jitsi/tasks/ldap_auth.yml
@@ -47,7 +47,6 @@
     state: present
   loop:
     - sasl2-bin  # Necessary for Cyrus' saslauthd
-    - libsasl2-modules-ldap  # Necessary for Cyrus' saslauthdp
     - lua-cyrussasl  # Necessary for Prosody to access Cyrusd
     - liblua5.2-dev  # Necessary for Prosody to access Cyrus
   tags:

--- a/ansible/roles/sasl/tasks/main.yml
+++ b/ansible/roles/sasl/tasks/main.yml
@@ -4,7 +4,6 @@
     name:
       - sasl2-bin
       - libsasl2-modules
-      - libsasl2-modules-ldap
     state: present
   tags:
     - role::sasl


### PR DESCRIPTION
This caused problems in postfix's logfile, our most holy daemon. We must
not disturb it, and as an aside, everything works fine.
