### PR TITLE
ManageSieve for Everyone

### DIFF
--- a/ansible/group_vars/all/nftables.yml
+++ b/ansible/group_vars/all/nftables.yml
@@ -18,6 +18,8 @@ nftables_configuration: |
     set mail_accepted {
       type inet_service
       elements = {
+        # Mail configuration
+        sieve,
         # Mail submission
         smtp,
         smtps,

--- a/ansible/roles/dovecot/tasks/main.yml
+++ b/ansible/roles/dovecot/tasks/main.yml
@@ -120,7 +120,7 @@
     dest: "{{ dovecot_sieve_pipe_bin_dir }}/{{ item }}"
     owner: vmail
     group: vmail
-    mode: "0500"
+    mode: "0555"
   with_items:
     - spamc-learn-ham.sh
     - spamc-learn-spam.sh

--- a/ansible/roles/dovecot/templates/configs/10-mail.conf.j2
+++ b/ansible/roles/dovecot/templates/configs/10-mail.conf.j2
@@ -433,6 +433,9 @@ service welcome {
   executable = script /etc/dovecot/welcome.sh
   user = dovecot
   unix_listener welcome {
+    # Group write permissions are necessary to allow this to run for new users.
+    mode = 0660
     user = vmail
+    group = vmail
   }
 }

--- a/ansible/roles/dovecot/templates/configs/10-mail.conf.j2
+++ b/ansible/roles/dovecot/templates/configs/10-mail.conf.j2
@@ -29,7 +29,7 @@
 #
 # <doc/wiki/MailLocation.txt>
 #
-mail_home = /var/vmail/%d/%n
+mail_home = /var/vmail/%u
 mail_location = maildir:~/mail
 
 

--- a/ansible/roles/dovecot/templates/configs/auth-ldap.conf.ext.j2
+++ b/ansible/roles/dovecot/templates/configs/auth-ldap.conf.ext.j2
@@ -12,6 +12,10 @@ passdb {
 }
 
 userdb {
-  driver = static
-  args = uid=vmail gid=vmail home=/var/vmail/%u mail=maildir:~/mail sieve=/home/%u/sieve sieve_user_log=/var/vmail/%u/sieve.log
+  driver = prefetch
+}
+
+userdb {
+  driver = ldap
+  args = /etc/dovecot/dovecot-ldap.conf.ext
 }

--- a/ansible/roles/dovecot/templates/dovecot-ldap.conf.ext.j2
+++ b/ansible/roles/dovecot/templates/dovecot-ldap.conf.ext.j2
@@ -56,7 +56,7 @@ base = cn=users,cn=accounts,dc=box,dc=pydis,dc=wtf
 #
 # There are also other special fields which can be returned, see
 # http://wiki2.dovecot.org/UserDatabase/ExtraFields
-user_attrs = uidNumber=uid, gidNumber=gid, uid=home=/home/%$
+user_attrs = uidNumber=uid, gidNumber=gid, mail=maildir:~/mail, homeDirectory=/var/vmail/%n, sieve=~/main.sieve sieve_user_log=~/sieve.log
 
 # Filter for user lookup. Some variables can be used (see
 # http://wiki2.dovecot.org/Variables for full list):

--- a/ansible/roles/dovecot/templates/dovecot-ldap.conf.ext.j2
+++ b/ansible/roles/dovecot/templates/dovecot-ldap.conf.ext.j2
@@ -56,7 +56,7 @@ base = cn=users,cn=accounts,dc=box,dc=pydis,dc=wtf
 #
 # There are also other special fields which can be returned, see
 # http://wiki2.dovecot.org/UserDatabase/ExtraFields
-user_attrs = uidNumber=uid, gidNumber=gid, mail=maildir:~/mail, homeDirectory=/var/vmail/%n, sieve=~/main.sieve sieve_user_log=~/sieve.log
+user_attrs = uidNumber=uid, gidNumber=gid, sieve=~/main.sieve, sieve_user_log=~/sieve.log
 
 # Filter for user lookup. Some variables can be used (see
 # http://wiki2.dovecot.org/Variables for full list):

--- a/ansible/roles/dovecot/templates/dovecot.conf.j2
+++ b/ansible/roles/dovecot/templates/dovecot.conf.j2
@@ -87,12 +87,6 @@ dict {
   #quota = mysql:/etc/dovecot/dovecot-dict-sql.conf.ext
 }
 
-# PYDIS CONFIG START
-
-protocols = imap lmtp
-
-# PYDIS CONFIG END
-
 # Most of the actual configuration gets included below. The filenames are
 # first sorted by their ASCII value and parsed in that order. The 00-prefixes
 # in filenames are intended to make it easier to understand the ordering.

--- a/docs/docs/services/email/mail-clients.md
+++ b/docs/docs/services/email/mail-clients.md
@@ -60,15 +60,14 @@ are not provided by the PyDis mailserver please let us know in `#dev-oops`.
 
 We support server-side email filtering with [Pigeonhole
 Sieve](https://doc.dovecot.org/configuration_manual/sieve/pigeonhole_sieve_interpreter/).
+Sieve scripts are managed via [the ManageSieve
+protocol](https://datatracker.ietf.org/doc/html/rfc5804). Your e-mail client
+should have built-in functionality for writing and editing these scripts. For a
+listing of clients, see [the official Sieve website](http://sieve.info/clients).
 
-!!! example "DevOps Only"
-
-    For now, since this feature requires access to a home directory on the host, it is
-    only accessable to members of the DevOps team. If you are not a member of the DevOps
-    team and wish to configure sieve, please let us know in the #dev-oops channel.
-
-    We may in future investigate further usage of `dovecot-managesieved` to allow for
-    remote management of the Sieve filters.
+If you're looking for a command-line client,
+[`sieve-connect`](https://people.spodhuis.org/phil.pennock/software/) may be
+what you are looking for.
 
 Using this, users can perform common mail tasks automatically by writing small
 sieve scripts that are able to act on inbound mail before it reaches a user

--- a/docs/docs/services/email/mail-clients.md
+++ b/docs/docs/services/email/mail-clients.md
@@ -62,12 +62,12 @@ We support server-side email filtering with [Pigeonhole
 Sieve](https://doc.dovecot.org/configuration_manual/sieve/pigeonhole_sieve_interpreter/).
 Sieve scripts are managed via [the ManageSieve
 protocol](https://datatracker.ietf.org/doc/html/rfc5804). Your e-mail client
-should have built-in functionality for writing and editing these scripts. For a
-listing of clients, see [the official Sieve website](http://sieve.info/clients).
+should have built-in functionality for writing and editing these scripts. See
+[the official Sieve website](http://sieve.info/) for more information.
 
-If you're looking for a command-line client,
-[`sieve-connect`](https://people.spodhuis.org/phil.pennock/software/) may be
-what you are looking for.
+If you're looking for clients, [`sieve-connect` is a solid
+CLI](https://people.spodhuis.org/phil.pennock/software/), and [Thomas Schmid's
+`sieve`](https://github.com/thsmi/sieve) is a solid GUI.
 
 Using this, users can perform common mail tasks automatically by writing small
 sieve scripts that are able to act on inbound mail before it reaches a user


### PR DESCRIPTION
A spectre is haunting Python Discord -- the spectre of proprietary mail
filtering programs. All the Powers of Big Mail have entered into a holy
alliance to exorcise this spectre: Outlook and GMail, Yahoo and Zoho,
AOL adn iCloud.

Where is the open protocol in opposition that has not been decried as
unprofessional, free and open source by its opponents in power? Where is
the Opposition that has not hurled back the branding reproach of
Internet Standards, against the more advanced opposition protocols, as
well as against its reactionary adversaries?

Two things result from this fact.

I.  Sieve is already standardized as a protocol via the IETF.

II. It is high time that Python Discord users should openly, in the face
of the TLS-encrypted internet, filter their notifications, their love
letters, their mailing lists, and meet this nursery tale of the Spectre
of ManageSieve with a Manifesto of Python Discord Devops itself.

To this end, ManageSieve users of various nationalities have assembled
on jitsi.pydis.wtf, and sketched the following commit, to be published
on the lovelace Python Discord e-mail service.
