### PR TITLE
Include Uncle Christ's Assorted Works in mirror

### DIFF
--- a/ansible/roles/git-mirrors/tasks/main.yml
+++ b/ansible/roles/git-mirrors/tasks/main.yml
@@ -66,7 +66,7 @@
       - "git"
       - "clone"
       - "--mirror"
-      - "https://github.com/{{ item.owner }}/{{ item.repo }}.git"
+      - "https://{{ item.domain | default('github.com') }}/{{ item.owner }}/{{ item.repo }}.git"
       - "{{ git_mirrors_base_dir }}/mirrored/{{ item.owner }}/{{ item.repo }}"
     creates: "{{ git_mirrors_base_dir }}/mirrored/{{ item.owner }}/{{ item.repo }}"
   with_items:

--- a/ansible/roles/git-mirrors/vars/main.yml
+++ b/ansible/roles/git-mirrors/vars/main.yml
@@ -67,6 +67,13 @@ git_mirrors_mirrored_repositories:
     description: >-
       Owl Corp surveillance storage platform
 
+  # Uncle Christ's Assorted Works
+  - owner: jc
+    repo: poetry-restrict-plugin
+    domain: git.jchri.st
+    description: >-
+      The Last Stand against malware in Python packages
+
 git_mirrors_nginx_domain: "git.pydis.wtf"
 git_mirrors_nginx_cert_file: "/etc/letsencrypt/live/pydis.wtf/fullchain.pem"
 git_mirrors_nginx_cert_key: "/etc/letsencrypt/live/pydis.wtf/privkey.pem"


### PR DESCRIPTION
Uncle Christ would like to mirror this item on the Python Discord git
mirror to ensure the security of Python Discord DevOps poetry
dependencies is included. Uncle Christ stands hopeful that this change
contributes to a better society.
