### PR TITLE
Sieve: Prevent duplicates

### DIFF
--- a/ansible/roles/dovecot/handlers/main.yml
+++ b/ansible/roles/dovecot/handlers/main.yml
@@ -13,6 +13,10 @@
   command: /usr/bin/sievec /etc/dovecot/sieve-after/spam-to-folder.sieve
   changed_when: true
 
+- name: Recompile prevent-duplicates sieve script
+  command: /usr/bin/sievec /etc/dovecot/sieve-after/prevent-duplicates.sieve
+  changed_when: true
+
 - name: Recompile learn-spam sieve script
   command: /usr/bin/sievec /etc/dovecot/sieve/learn-spam.sieve
   changed_when: true

--- a/ansible/roles/dovecot/tasks/main.yml
+++ b/ansible/roles/dovecot/tasks/main.yml
@@ -76,6 +76,18 @@
   tags:
     - role::dovecot
 
+- name: Template prevent-duplicates sieve script
+  template:
+    src: prevent-duplicates.sieve.j2
+    dest: /etc/dovecot/sieve-after/prevent-duplicates.sieve
+    owner: vmail
+    group: vmail
+    mode: "0444"
+  notify:
+    - Recompile prevent-duplicates sieve script
+  tags:
+    - role::dovecot
+
 - name: Set up sieve configuration for dovecot
   lineinfile:
     path: /etc/dovecot/conf.d/90-sieve.conf

--- a/ansible/roles/dovecot/templates/prevent-duplicates.sieve.j2
+++ b/ansible/roles/dovecot/templates/prevent-duplicates.sieve.j2
@@ -1,0 +1,9 @@
+# Ansible managed
+
+require ["duplicate"];
+
+if not exists "List-ID" {
+  if duplicate {
+    discard;
+  }
+}


### PR DESCRIPTION
This sieve filter prevents the delivery of messages to an inbox if they have a
duplicate message ID.

As defined in [RFC7352](https://tools.ietf.org/html/rfc7352) we use the
`duplicate` extension in Sieve to detect messages that have an identical
`Message-ID` header and discard them if they match.

I have opted to exclude any message that is part of a mailing list from this as
recommended by various users on Dovecot forums[^1], it is unlikely a user will
receive duplicate message-id's from a mailing list without good reason.

[^1]: https://www.dovecot.org/list/dovecot/2016-April/104050.html