### PR TITLE
Update git mirror once a day

### DIFF
--- a/ansible/roles/git-mirrors/tasks/main.yml
+++ b/ansible/roles/git-mirrors/tasks/main.yml
@@ -146,8 +146,9 @@
 - name: Add cronjob for mirror updating
   cron:
     name: "Update the git mirrors published by cgit (git-mirrors role)"
-    # Every 5 minutes
-    minute: "*/5"
+    # Every day at 4:27 AM
+    hour: "4"
+    minute: "27"
     job: "chronic {{ git_mirrors_base_dir }}/update-mirrors.sh"
     user: git-mirrors
     cron_file: "{{ git_mirrors_cron_file }}"

--- a/ansible/roles/git-mirrors/vars/main.yml
+++ b/ansible/roles/git-mirrors/vars/main.yml
@@ -5,7 +5,7 @@ git_mirrors_error_email: "devops@pydis.wtf"
 
 git_mirrors_cgit_logo: "https://raw.githubusercontent.com/python-discord/ops-site/main/src/images/icon.png"
 git_mirrors_cgit_title: PyDis DevOps Git Server
-git_mirrors_cgit_description: Mirrored copies of Python Discord and related projects
+git_mirrors_cgit_description: Mirrored copies of Python Discord and related projects. Updated once a day.
 
 git_mirrors_cron_file: "ansible_git_mirrors_update"
 


### PR DESCRIPTION
We do not commit code nearly enough to warrant us checking for updates
on all repositories every day. I would even go as far as saying that
some repositories are updated rarely enough that they do not need to be
checked every day either.
