### PR TITLE
Enable Wireguard on LDAP01

### DIFF
--- a/ansible/inventory/hosts.yaml
+++ b/ansible/inventory/hosts.yaml
@@ -5,6 +5,7 @@ all:
       wireguard_subnet: 10.2.0.0/16
     ldap01:
       ansible_host: ldap01.box.pydis.wtf
+      wireguard_subnet: 10.3.0.0/16
   children:
     netcup:
       hosts:

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -3,6 +3,7 @@
   roles:
     - common
     - pydis-mtls
+    - wireguard
 
 - name: Deploy services to Netcup nodes
   hosts: netcup
@@ -11,7 +12,6 @@
     - alloy
     - nftables
     - prometheus-node-exporter
-    - wireguard
     - fail2ban
     - podman
     - unattended-upgrades

--- a/ansible/roles/wireguard/defaults/main/vars.yml
+++ b/ansible/roles/wireguard/defaults/main/vars.yml
@@ -2,3 +2,11 @@ wireguard_extra_keys:
   - name: Joe
     pubkey: /dJ+tKXzxv7nrUleNlF+CGyq7OIVlqL8/9Sn8j+cEAc=
     subnet: 10.0.1.0/24
+
+wireguard_os_packages:
+  Debian:
+    - wireguard
+    - wireguard-tools
+    - linux-headers-{{ ansible_kernel }}
+  Rocky:
+    - wireguard-tools

--- a/ansible/roles/wireguard/tasks/main.yml
+++ b/ansible/roles/wireguard/tasks/main.yml
@@ -1,11 +1,7 @@
 - name: Install WireGuard
-  apt:
-    update_cache: true
-    cache_valid_time: 3600
-    pkg:
-      - wireguard
-      - wireguard-tools
-      - linux-headers-{{ ansible_kernel }}
+  package:
+    state: present
+    name: "{{ wireguard_os_packages[ansible_distribution] }}"
   tags:
     - role::wireguard
 

--- a/ansible/roles/wireguard/templates/wg0.conf.j2
+++ b/ansible/roles/wireguard/templates/wg0.conf.j2
@@ -5,8 +5,9 @@ ListenPort = {{ wireguard_port }}
 PrivateKey = {{ wg_priv_key['content'] | b64decode | trim }}
 
 PostUp = ip route add local {{ wireguard_subnet }} dev eth0
+PreDown = ip route del local {{ wireguard_subnet }} dev eth0
 
-{% for host in groups["netcup"] if not host == inventory_hostname %}
+{% for host in hostvars if not host == inventory_hostname %}
 # Peer config for: {{ host }}
 [Peer]
 AllowedIPs = {{ hostvars[host]['wireguard_subnet'] }}


### PR DESCRIPTION
- Add Wireguard subnet for ldap01 into Ansible Inventory
- Run Wireguard role on all hosts
- Dynamically determine packages to install for Wireguard based on host
  distribution
- Update templated Wireguard configuration such that:
  - We include a previously missing `PreDown` task that would prevent the
    `wg-quick@wg0.service` unit from being restarted (since the local table
    entry was duplicated)
  - We template Ansible configuration from all hosts since we now have Wireguard
    on both our Debian and Rocky boxes.