### PR TITLE
Raise time threshold for 4xx alerts

### DIFF
--- a/kubernetes/namespaces/monitoring/alerts/alerts.d/nginx.yaml
+++ b/kubernetes/namespaces/monitoring/alerts/alerts.d/nginx.yaml
@@ -4,7 +4,7 @@ groups:
 
   - alert: nginx/4xx-requests
     expr: sum by (service, status) (rate(nginx_ingress_controller_requests{service!="pixels",status!~"404|444",status=~"^4.."}[1m])) / sum by (service, status) (rate(nginx_ingress_controller_requests[1m])) > 0.5
-    for: 1m
+    for: 10m
     labels:
       severity: page
     annotations:


### PR DESCRIPTION
At present we get plenty of unactionable, flapping alarms. So far, they
have shown us nothing of value. Raise the time consecutive errors need
to be seen before we alert.
