### PR TITLE
Ansible Lint improvements

### DIFF
--- a/.github/workflows/lint-ansible.yaml
+++ b/.github/workflows/lint-ansible.yaml
@@ -22,10 +22,20 @@ jobs:
           install_args: --only ansible
           checkout: false
 
+      - name: Cache Ansible dependencies
+        id: cache-ansible
+        uses: actions/cache@v4
+        with:
+          path: ansible/.ansible
+          key: ansible-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'poetry.lock', 'ansible/roles/requirements.yml') }}
+
+      - name: Install Ansible Galaxy dependencies
+        run: cd ansible && ansible-galaxy install -r roles/requirements.yml
+
       - name: Run ansible lint
         run: |
           cd ansible
           # Remove any Vaulted files and Vault configuration
           grep -R '$ANSIBLE_VAULT;' --files-with-matches . | xargs rm
           sed --in-place '/vault_password_file/d' ansible.cfg
-          ansible-lint
+          ansible-lint --exclude .ansible

--- a/.github/workflows/lint-ansible.yaml
+++ b/.github/workflows/lint-ansible.yaml
@@ -8,12 +8,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          sparse-checkout: |
+            ansible
+            pyproject.toml
+            poetry.lock
 
       - name: Install Python Dependencies
         uses: HassanAbouelela/actions/setup-python@setup-python_v1.6.0
         with:
-          python_version: '3.11'
+          python_version: "3.11"
           install_args: --only ansible
+          checkout: false
 
       - name: Run ansible lint
         run: |

--- a/ansible/.ansible-lint
+++ b/ansible/.ansible-lint
@@ -4,7 +4,9 @@ exclude_paths:
   - roles/certbot/vars/main/vault.yml
   # Submodules
   - roles/nftables
+  - roles/prometheus-postgres-exporter
 skip_list:
   - fqcn-builtins
   - meta-no-info
   - role-name
+  - jinja[spacing]


### PR DESCRIPTION
- Ignore Jinja spacing rule that caused noise in output
- Update git checkouts to improve role speed and use sparse checkouts
- Ignore the Prometheus Postgres Exporter which is a submodule and cannot be
  linted by our rules
  
Closes #525