### PR TITLE
Add all accepted mail domains to SRS exclude configuration

### DIFF
--- a/ansible/roles/postfix/handlers/main.yml
+++ b/ansible/roles/postfix/handlers/main.yml
@@ -20,3 +20,8 @@
 - name: Regenerate sender access table
   command: postmap /etc/postfix/sender_access
   changed_when: true
+
+- name: Restart postsrsd
+  service:
+    name: postsrsd
+    state: restarted

--- a/ansible/roles/postfix/tasks/main.yml
+++ b/ansible/roles/postfix/tasks/main.yml
@@ -158,6 +158,22 @@
   tags:
     - role::postfix
 
+- name: Update PostSRSD rewriting config
+  lineinfile:
+    path: /etc/default/postsrsd
+    regexp: "^#?{{ item['key'] }}="
+    line: '{{ item["key"] }}="{{ item["value"] }}"'
+    mode: "0444"
+    owner: root
+    group: root
+  loop:
+    - key: SRS_EXCLUDE_DOMAINS
+      value: "{{ postfix_destination_domains | join(',') }}"
+  tags:
+    - role::postfix
+  notify:
+    - Restart postsrsd
+
 - name: Pass inbound mail through spamassassin content filter
   lineinfile:
     path: /etc/postfix/master.cf


### PR DESCRIPTION
We don't want to rewrite the envelopes of mail that is from a valid
domain of our mailserver (e.g. pydis.com or int.pydis.wtf), but by
default PostSRSD will rewrite anything that is not the `mydomain`
configuration variable of Postfix (which is just set to `pydis.wtf` for
us).

This change updates the environment defaults for PostSRSD to ensure that
we don't change any envelopes that don't need to be changed, as well as
ensuring that to end mailservers the DKIM and SPF checks are made
against the actual domain (e.g. int.pydis.wtf) instead of the rewritten
envelope.