### PR TITLE
Treat NGINX responses as UTF-8

### DIFF
--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -25,6 +25,23 @@
   file:
     path: /etc/nginx/sites-enabled/default
     state: absent
+  tags:
+    - role::nginx
+
+- name: Copy conf.d entries
+  template:
+    src: "{{ item }}"
+    dest: "/etc/nginx/conf.d/{{ item | basename | splitext | first }}"
+    mode: "0444"
+    owner: root
+    group: root
+  with_fileglob: "../templates/nginx-conf.d/*"
+  loop_control:
+    label: "{{ item | basename | splitext | first }}"
+  tags:
+    - role::nginx
+  notify:
+    - Reload the nginx service
 
 - name: Copy host-specific configs
   copy:

--- a/ansible/roles/nginx/templates/nginx-conf.d/charset.conf.j2
+++ b/ansible/roles/nginx/templates/nginx-conf.d/charset.conf.j2
@@ -1,0 +1,2 @@
+# {{ ansible_managed }}
+charset utf-8;


### PR DESCRIPTION
Some sites that had non-ASCII characters rendered weirdly because our
NGINX configuration was not returning a default charset and so rendering
was being left up to browser/standards defaults.

This change adds a new config file to /etc/nginx/conf.d/ which forces
responses to be interpreted as/transformed to UTF-8.