### PR TITLE
Refactor "Managed by Ansible" notices in templates

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -5,6 +5,8 @@ vault_password_file = vault_passwords
 collections_path = .ansible/galaxy_collections/
 roles_path = .ansible/galaxy_roles/:roles/
 
+ansible_managed = Managed by Ansible (do not edit). Role: {{{{ role_name }}}}, Template: {{{{ template_path | basename }}}}
+
 [privilege_escalation]
 become = yes
 

--- a/ansible/roles/alloy/templates/config.alloy.j2
+++ b/ansible/roles/alloy/templates/config.alloy.j2
@@ -1,4 +1,4 @@
-// Managed by Ansible
+// {{ ansible_managed }}
 
 logging {
   level = "info"

--- a/ansible/roles/dovecot-monitoring/templates/maildir-mails.sh.j2
+++ b/ansible/roles/dovecot-monitoring/templates/maildir-mails.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Ansible managed
+# {{ ansible_managed }}
 
 cd /var/vmail && \
   find . \

--- a/ansible/roles/dovecot-monitoring/templates/maildir-sizes.sh.j2
+++ b/ansible/roles/dovecot-monitoring/templates/maildir-sizes.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Ansible managed
+# {{ ansible_managed }}
 
 cd /var/vmail && \
   du --bytes --summarize -- * \

--- a/ansible/roles/dovecot/tasks/main.yml
+++ b/ansible/roles/dovecot/tasks/main.yml
@@ -111,8 +111,8 @@
     - learn-ham.sieve
   notify:
     - Restart Dovecot
-    - Recompile dovecot learn-spam sieve script
-    - Recompile dovecot learn-ham sieve script
+    - Recompile learn-spam sieve script
+    - Recompile learn-ham sieve script
   tags:
     - role::dovecot
 

--- a/ansible/roles/dovecot/templates/configs/10-auth.conf.j2
+++ b/ansible/roles/dovecot/templates/configs/10-auth.conf.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 ##
 ## Authentication processes

--- a/ansible/roles/dovecot/templates/configs/10-mail.conf.j2
+++ b/ansible/roles/dovecot/templates/configs/10-mail.conf.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 ##
 ## Mailbox locations and namespaces

--- a/ansible/roles/dovecot/templates/configs/10-master.conf.j2
+++ b/ansible/roles/dovecot/templates/configs/10-master.conf.j2
@@ -1,4 +1,4 @@
-# Ansible Managed
+# {{ ansible_managed }}
 
 #default_process_limit = 100
 #default_client_limit = 1000

--- a/ansible/roles/dovecot/templates/configs/10-ssl.conf.j2
+++ b/ansible/roles/dovecot/templates/configs/10-ssl.conf.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 ##
 ## SSL settings

--- a/ansible/roles/dovecot/templates/configs/15-mailboxes.conf.j2
+++ b/ansible/roles/dovecot/templates/configs/15-mailboxes.conf.j2
@@ -1,4 +1,4 @@
-# Ansible managed
+# {{ ansible_managed }}
 
 ##
 ## Mailbox definitions

--- a/ansible/roles/dovecot/templates/configs/20-imap.conf.j2
+++ b/ansible/roles/dovecot/templates/configs/20-imap.conf.j2
@@ -1,4 +1,4 @@
-# Ansible Managed
+# {{ ansible_managed }}
 
 ##
 ## IMAP specific settings

--- a/ansible/roles/dovecot/templates/configs/20-lmtp.conf.j2
+++ b/ansible/roles/dovecot/templates/configs/20-lmtp.conf.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 ##
 ## LMTP specific settings

--- a/ansible/roles/dovecot/templates/configs/auth-ldap.conf.ext.j2
+++ b/ansible/roles/dovecot/templates/configs/auth-ldap.conf.ext.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 # Authentication for LDAP users. Included from 10-auth.conf.
 #

--- a/ansible/roles/dovecot/templates/dovecot-ldap.conf.ext.j2
+++ b/ansible/roles/dovecot/templates/dovecot-ldap.conf.ext.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 # This file is commonly accessed via passdb {} or userdb {} section in
 # conf.d/auth-ldap.conf.ext

--- a/ansible/roles/dovecot/templates/dovecot.conf.j2
+++ b/ansible/roles/dovecot/templates/dovecot.conf.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 ## Dovecot configuration file
 

--- a/ansible/roles/dovecot/templates/learn-ham.sieve.j2
+++ b/ansible/roles/dovecot/templates/learn-ham.sieve.j2
@@ -1,4 +1,4 @@
-# Ansible managed
+# {{ ansible_managed }}
 
 require ["vnd.dovecot.pipe", "copy", "imapsieve", "variables"];
 

--- a/ansible/roles/dovecot/templates/learn-spam.sieve.j2
+++ b/ansible/roles/dovecot/templates/learn-spam.sieve.j2
@@ -1,4 +1,4 @@
-# Ansible managed
+# {{ ansible_managed }}
 
 require ["vnd.dovecot.pipe", "copy", "imapsieve"];
 

--- a/ansible/roles/dovecot/templates/prevent-duplicates.sieve.j2
+++ b/ansible/roles/dovecot/templates/prevent-duplicates.sieve.j2
@@ -1,4 +1,4 @@
-# Ansible managed
+# {{ ansible_managed }}
 
 require ["duplicate"];
 

--- a/ansible/roles/dovecot/templates/spam-to-folder.sieve.j2
+++ b/ansible/roles/dovecot/templates/spam-to-folder.sieve.j2
@@ -1,4 +1,4 @@
-# Ansible managed
+# {{ ansible_managed }}
 
 require ["fileinto"];
 

--- a/ansible/roles/git-mirrors/templates/cgitrc.j2
+++ b/ansible/roles/git-mirrors/templates/cgitrc.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 # See cgitrc(5) for details
 

--- a/ansible/roles/munin-node/templates/munin-node.conf.j2
+++ b/ansible/roles/munin-node/templates/munin-node.conf.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 log_level 4
 

--- a/ansible/roles/munin-node/templates/plugin.conf.j2
+++ b/ansible/roles/munin-node/templates/plugin.conf.j2
@@ -1,4 +1,4 @@
-# Ansible managed
+# {{ ansible_managed }}
 
 [dovecot_maildirs]
 user root

--- a/ansible/roles/munin-node/templates/plugins/lovelace/dovecot_maildirs.sh.j2
+++ b/ansible/roles/munin-node/templates/plugins/lovelace/dovecot_maildirs.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Ansible managed
+# {{ ansible_managed }}
 
 cd /var/vmail || exit 1
 

--- a/ansible/roles/munin-node/templates/plugins/lovelace/lovering_inheritance.py.j2
+++ b/ansible/roles/munin-node/templates/plugins/lovelace/lovering_inheritance.py.j2
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Ansible managed
+# {{ ansible_managed }}
 
 import datetime
 import random

--- a/ansible/roles/munin/templates/munin.conf.j2
+++ b/ansible/roles/munin/templates/munin.conf.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 # The next three variables specifies where the location of the RRD
 # databases, the HTML output, logs and the lock/pid files.  They all

--- a/ansible/roles/nginx/templates/default_server.conf
+++ b/ansible/roles/nginx/templates/default_server.conf
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 server {
   listen 80 default_server;
 

--- a/ansible/roles/opendkim/templates/opendkim.conf.j2
+++ b/ansible/roles/opendkim/templates/opendkim.conf.j2
@@ -1,4 +1,4 @@
-# Ansible Managed
+# {{ ansible_managed }}
 
 # Common signing and verification parameters. In Debian, the "From" header is
 # oversigned, because it is often the identity key used by reputation systems

--- a/ansible/roles/opendmarc-inbox/templates/dmarc.sieve.j2
+++ b/ansible/roles/opendmarc-inbox/templates/dmarc.sieve.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 require ["fileinto", "envelope", "subaddress", "mailbox"];
 

--- a/ansible/roles/postfix/templates/header-checks-submission.j2
+++ b/ansible/roles/postfix/templates/header-checks-submission.j2
@@ -1,4 +1,4 @@
-# Ansible managed
+# {{ ansible_managed }}
 # Taken from the excellent mailinabox project:
 # https://github.com/mail-in-a-box/mailinabox/blob/ddf8e857fdb2ac3508af9339abcdd908835f899b/conf/postfix_outgoing_mail_header_filters
 #

--- a/ansible/roles/postfix/templates/ldap/ldap-group-aliases.cf.j2
+++ b/ansible/roles/postfix/templates/ldap/ldap-group-aliases.cf.j2
@@ -1,4 +1,4 @@
-# Ansible Managed
+# {{ ansible_managed }}
 
 server_host = {{ postfix_bind_server }}
 bind = yes

--- a/ansible/roles/postfix/templates/ldap/ldap-registeredaddress.cf.j2
+++ b/ansible/roles/postfix/templates/ldap/ldap-registeredaddress.cf.j2
@@ -1,4 +1,4 @@
-# Ansible Managed
+# {{ ansible_managed }}
 
 server_host = {{ postfix_bind_server }}
 bind = yes

--- a/ansible/roles/postfix/templates/ldap/ldap-relay-recipients.cf.j2
+++ b/ansible/roles/postfix/templates/ldap/ldap-relay-recipients.cf.j2
@@ -1,4 +1,4 @@
-# Ansible Managed
+# {{ ansible_managed }}
 
 server_host = {{ postfix_bind_server }}
 bind = yes

--- a/ansible/roles/postfix/templates/ldap/ldap-service-mail.cf.j2
+++ b/ansible/roles/postfix/templates/ldap/ldap-service-mail.cf.j2
@@ -1,4 +1,4 @@
-# Ansible Managed
+# {{ ansible_managed }}
 
 server_host = {{ postfix_bind_server }}
 bind = yes

--- a/ansible/roles/postfix/templates/ldap/ldap-uid.cf.j2
+++ b/ansible/roles/postfix/templates/ldap/ldap-uid.cf.j2
@@ -1,4 +1,4 @@
-# Ansible Managed
+# {{ ansible_managed }}
 
 server_host = {{ postfix_bind_server }}
 bind = yes

--- a/ansible/roles/postfix/templates/main.cf.j2
+++ b/ansible/roles/postfix/templates/main.cf.j2
@@ -1,4 +1,4 @@
-# Ansible Managed
+# {{ ansible_managed }}
 
 smtpd_banner = $myhostname ESMTP $mail_name (Debian/GNU)
 biff = no

--- a/ansible/roles/postfix/templates/transport.j2
+++ b/ansible/roles/postfix/templates/transport.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 #
 # Postfix Mail Transport Map
 

--- a/ansible/roles/rrdstats/templates/generate-rrdtool-stats.service.j2
+++ b/ansible/roles/rrdstats/templates/generate-rrdtool-stats.service.j2
@@ -1,4 +1,4 @@
-# Ansible managed
+# {{ ansible_managed }}
 [Unit]
 Description = Generate Python Discord statistics via rrdtool
 After = postgresql.service

--- a/ansible/roles/rrdstats/templates/generate-rrdtool-stats.timer.j2
+++ b/ansible/roles/rrdstats/templates/generate-rrdtool-stats.timer.j2
@@ -1,4 +1,4 @@
-# Ansible managed
+# {{ ansible_managed }}
 
 [Unit]
 Description = Generate rrdtool stats minutely

--- a/ansible/roles/spamassassin/templates/local.cf.j2
+++ b/ansible/roles/spamassassin/templates/local.cf.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 # This is the right place to customize your installation of SpamAssassin.
 #

--- a/ansible/roles/wireguard/templates/wg0.conf.j2
+++ b/ansible/roles/wireguard/templates/wg0.conf.j2
@@ -1,4 +1,4 @@
-# Configuration managed by Ansible
+# {{ ansible_managed }}
 [Interface]
 Address = {{ wireguard_subnet }}
 ListenPort = {{ wireguard_port }}


### PR DESCRIPTION
As of now, we have no coherence between "Managed by Ansible" and have a mix of
this string and "Ansible Managed".

We also have no indication on the remote filesystem to which role a given
templated file belongs or how to locate it once it's deployed.

I propose that we change to using the built-in `{{ ansible_managed }}` tag on
any template that we wish to signify is managed by our Ansible setup. On the
remote systems, this renders something like this:

``` sh
joe@lovelace:~$ cat /etc/nginx/conf.d/charset.conf
# Managed by Ansible. Belongs to nginx role.
charset utf-8;
```

I haven't finalised the format or which variables to include (though for obvious
reasons they should be static variables), hence why this is a draft.

I also haven't yet gone through to update templates with this change and re-run
all roles.