### PR TITLE
Don't apply SRS to locally bound mail

### DIFF
--- a/ansible/roles/postfix/tasks/main.yml
+++ b/ansible/roles/postfix/tasks/main.yml
@@ -198,12 +198,12 @@
         -o smtpd_sasl_path=private/auth
 
       cleanup-srs     unix n - - - 0 cleanup
-        -o syslog_name=postfix/srs
+        -o syslog_name=postfix/cleanup/optional-srs
         -o sender_canonical_maps=pcre:/etc/postfix/sender-canonical-maps,tcp:127.0.0.1:10001
         -o sender_canonical_classes=envelope_sender
 
-      127.0.0.1:10027 inet n - - - - smtpd
-        -o syslog_name=postfix/srs
+      127.0.0.1:10027 inet n - y - - smtpd
+        -o syslog_name=postfix/cleanup/optional-srs
         -o smtpd_milters=
         -o cleanup_service_name=cleanup-srs
         -o smtpd_tls_security_level=none

--- a/ansible/roles/postfix/tasks/main.yml
+++ b/ansible/roles/postfix/tasks/main.yml
@@ -90,6 +90,16 @@
   notify:
     - Restart postfix
 
+- name: Template sender canonical map lookup
+  template:
+    src: sender-canonical-maps.j2
+    dest: /etc/postfix/sender-canonical-maps
+    mode: "0644"
+    group: root
+    owner: root
+  tags:
+    - role::postfix
+
 - name: Create Postfix service directory
   file:
     path: "/etc/postfix/service-scripts"
@@ -186,6 +196,19 @@
         -o smtpd_recipient_restrictions=permit_mynetworks,permit_sasl_authenticated,reject
         -o smtpd_sasl_type=dovecot
         -o smtpd_sasl_path=private/auth
+
+      cleanup-srs     unix n - - - 0 cleanup
+        -o syslog_name=postfix/srs
+        -o sender_canonical_maps=pcre:/etc/postfix/sender-canonical-maps,tcp:127.0.0.1:10001
+        -o sender_canonical_classes=envelope_sender
+
+      127.0.0.1:10027 inet n - - - - smtpd
+        -o syslog_name=postfix/srs
+        -o smtpd_milters=
+        -o cleanup_service_name=cleanup-srs
+        -o smtpd_tls_security_level=none
+        -o content_filter=smtp:
+        -o smtpd_recipient_restrictions=permit_mynetworks,reject
 
       # spamassassin filtering
       spamassassin unix -     n       n       -       -       pipe

--- a/ansible/roles/postfix/templates/main.cf.j2
+++ b/ansible/roles/postfix/templates/main.cf.j2
@@ -48,7 +48,12 @@ myhostname = {{ postfix_mailserver_name }}
 
 policyd-spf_time_limit = 3600
 
-# Handle SRS
+# Set the default transport to our private separate smtpd instance
+# which will conditionally apply SRS (Sender Rewrite Scheme).
+#
+# If the mail is destined for a local inbox, no SRS is needed as we
+# are the final hop. If the mail is destined for a forwarding address
+# we apply SRS so that SPF and other validations will pass.
 default_transport = smtp:127.0.0.1:10027
 recipient_canonical_maps = tcp:localhost:10002
 recipient_canonical_classes = envelope_recipient,header_recipient

--- a/ansible/roles/postfix/templates/main.cf.j2
+++ b/ansible/roles/postfix/templates/main.cf.j2
@@ -48,8 +48,8 @@ myhostname = {{ postfix_mailserver_name }}
 
 policyd-spf_time_limit = 3600
 
-sender_canonical_maps = tcp:localhost:10001
-sender_canonical_classes = envelope_sender
+# Handle SRS
+default_transport = smtp:127.0.0.1:10027
 recipient_canonical_maps = tcp:localhost:10002
 recipient_canonical_classes = envelope_recipient,header_recipient
 

--- a/ansible/roles/postfix/templates/sender-canonical-maps.j2
+++ b/ansible/roles/postfix/templates/sender-canonical-maps.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+{% for domain in postfix_destination_domains %}
+/^(.+@{{ domain | replace(".", "\\.") }})$/    ${1}
+{% endfor %}


### PR DESCRIPTION
In #528 changes were made to prevent mail from internal domains being rewritten
with the Sender Rewrite Scheme since we can correctly authenticate any mail sent
from our domains.

Similarly, if we are the last stop on an envelopes journey (i.e. the mail will
arrive to a local mailbox) there is no need for us to apply sender rewriting as
we have no further mailservers to pass the message onto (and so the message is
fully received and validated at this point).

This PR introduces a new SMTP daemon which we set as the `default_transport`
which conditionally rewrites with SRS only when the expanded destination address
is not a locally handled inbox.

This allows for mail heading for an external server such as Google or Outlook to
be rewritten and remain valid under SPF but mail that lands in our inboxes not
be rewritten (you can validate this by checking that the `Return-Path` doesn't
have SRS in it for local mail).