### PR TITLE
Dovecot vmail uid/gid fixes

### DIFF
--- a/ansible/roles/dovecot/tasks/main.yml
+++ b/ansible/roles/dovecot/tasks/main.yml
@@ -29,6 +29,16 @@
   tags:
     - role::dovecot
 
+- name: Set permissions on /var/vmail directory
+  file:
+    path: /var/vmail
+    state: directory
+    owner: vmail
+    group: vmail
+    mode: "0775"
+  tags:
+    - role::dovecot
+
 - name: Copy welcome script
   copy:
     src: welcome.sh

--- a/ansible/roles/dovecot/templates/dovecot-ldap.conf.ext.j2
+++ b/ansible/roles/dovecot/templates/dovecot-ldap.conf.ext.j2
@@ -56,7 +56,7 @@ base = cn=users,cn=accounts,dc=box,dc=pydis,dc=wtf
 #
 # There are also other special fields which can be returned, see
 # http://wiki2.dovecot.org/UserDatabase/ExtraFields
-user_attrs = uidNumber=uid, gidNumber=gid, sieve=~/main.sieve, sieve_user_log=~/sieve.log
+user_attrs = uidNumber=uid, sieve=~/main.sieve, sieve_user_log=~/sieve.log
 
 # Filter for user lookup. Some variables can be used (see
 # http://wiki2.dovecot.org/Variables for full list):


### PR DESCRIPTION
Dovecot was unable to create new directories because we overrode both the uid and gid when creating the subfolders under `/var/vmail/`.

We now correct this by having mail delivery operate under the `uid` of the target recipient but the `vmail` group to allow for the directory creation and the insertion of the welcome message from the welcome Dovecot plugin.