### PR TITLE
Add minimum mongodb version

### DIFF
--- a/ansible/roles/mongodb/templates/mongodb.image.j2
+++ b/ansible/roles/mongodb/templates/mongodb.image.j2
@@ -5,6 +5,6 @@ Description = Mongo NoSQL (NonSensical Query Language) Server image
 After = network-online.target
 
 [Image]
-Image = docker.io/library/mongo:4.4
+Image = docker.io/library/mongo:4.4.29
 
 # vim: ft=dosini.jinja2:


### PR DESCRIPTION
4.4.29 is the v4 backport fix for mongobleed
https://www.heise.de/en/news/MongoBleed-Exploit-for-critical-vulnerability-in-MongoDB-makes-attacks-easier-11125127.html