### PR TITLE
Only deliver moderation alerts to the mod team

### DIFF
--- a/kubernetes/namespaces/monitoring/alerts/alertmanager.yaml
+++ b/kubernetes/namespaces/monitoring/alerts/alertmanager.yaml
@@ -7,18 +7,17 @@ route:
   group_interval: 1m
 
   routes:
-    - receiver: devops-team
-      continue: true
     - receiver: mod-team
       matchers:
         - additional_destination="mods"
-      continue: true
+
     - receiver: pagerduty
       matchers:
         - severity="page"
       continue: true
-    - receiver: email
+    - receiver: devops-team
       continue: true
+    - receiver: email
 
 receivers:
   - name: devops-team


### PR DESCRIPTION
The DevOps team does not concern itself with the problems of the chat
platform's moderator team.
