### PR TITLE
guix-sops: Pin channels, add simpler setup instructions

### DIFF
--- a/guix/README.md
+++ b/guix/README.md
@@ -16,23 +16,6 @@ as a playground for ideas.
     --generate-key` as root.
   - This is needed for the remote Guix instance to accept packages we build
     locally.
-- `sops-guix` configured as a channel. For this, add:
-
-  ```scheme
-  (cons* (channel
-        (name 'sops-guix)
-        (url "https://github.com/fishinthecalculator/sops-guix.git")
-        (branch "main")
-        ;; Enable signature verification:
-        (introduction
-         (make-channel-introduction
-          "0bbaf1fdd25266c7df790f65640aaa01e6d2dbc9"
-          (openpgp-fingerprint
-           "8D10 60B9 6BB8 292E 829B  7249 AED4 1CC1 93B7 01E2"))))
-       %default-channels)
-  ```
-
-  to your `~/.config/guix/channels.scm`. After adding it, run `guix pull`.
 - [`sops`](https://github.com/getsops/sops) installed locally, along with
   [`age`](https://github.com/FiloSottile/age).
 
@@ -62,6 +45,12 @@ sudo $(guix system container --network machines/turing.scm)
 
 ```sh
 # Optional, but recommended
-# guix pull
+#   guix pull
+# If you have the sops-guix channel configured locally:
 guix deploy deployment.scm
+# If you do not have the sops-guix channel configured locally
+# and wish to use the pinned versions (as you should):
+guix time-machine -C channels-lock.scm -- deploy deployment.scm
+# If you wish to sandbox the whole thing in a container:
+guix shell --preserve=^SSH_AUTH_SOCK --expose=/etc/guix --expose=$HOME/.ssh --share=$SSH_AUTH_SOCK --container --network --nesting guix -- guix time-machine -C channels-lock.scm -- deploy deployment.scm
 ```

--- a/guix/channels-lock.scm
+++ b/guix/channels-lock.scm
@@ -1,0 +1,20 @@
+(list (channel
+       (name 'sops-guix)
+       (url "https://github.com/fishinthecalculator/sops-guix.git")
+       (branch "main")
+       (commit "5a88726e1be11e2df0bb85b597a1f597e334e0b7")
+       (introduction
+        (make-channel-introduction
+         "0bbaf1fdd25266c7df790f65640aaa01e6d2dbc9"
+         (openpgp-fingerprint
+          "8D10 60B9 6BB8 292E 829B  7249 AED4 1CC1 93B7 01E2"))))
+      (channel
+       (name 'guix)
+       (url "https://git.guix.gnu.org/guix.git")
+       (branch "master")
+       (commit "4750a7657d73e01d45789b06f4b8154b61da5f7f")
+       (introduction
+        (make-channel-introduction
+         "9edb3f66fd807b096b48283debdcddccfea34bad"
+         (openpgp-fingerprint
+          "BBB0 2DDF 2CEA F6A8 0D1D  E643 A2A0 6DF2 A33A 54FA")))))


### PR DESCRIPTION
Renovate would be able to update something like the commit hashes in the lockfile, but it seems dependabot is not.