### PR TITLE
Be kind to GitHub

### DIFF
--- a/ansible/roles/git-mirrors/tasks/main.yml
+++ b/ansible/roles/git-mirrors/tasks/main.yml
@@ -146,8 +146,8 @@
 - name: Add cronjob for mirror updating
   cron:
     name: "Update the git mirrors published by cgit (git-mirrors role)"
-    # Every 5 minutes
-    minute: "*/5"
+    # Every hour
+    minute: "0"
     job: "chronic {{ git_mirrors_base_dir }}/update-mirrors.sh"
     user: git-mirrors
     cron_file: "{{ git_mirrors_cron_file }}"


### PR DESCRIPTION
The Python Discord Git Mirror Infrastructure Mirror Cronjob is causing
repeated GitHub outages. Be kinder.
