### PR TITLE
Add Alloy support to Rocky nodes

### DIFF
--- a/ansible/host_vars/ldap01/alloy.yml
+++ b/ansible/host_vars/ldap01/alloy.yml
@@ -1,0 +1,9 @@
+---
+alloy_extra_files:
+  - name: dirsrv_access
+    path: "/var/log/dirsrv/slapd-*/access"
+  - name: dirsrv_error
+    path: "/var/log/dirsrv/slapd-*/errors"
+
+alloy_extra_groups:
+  - dirsrv

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -5,6 +5,7 @@
     - common
     - pydis-mtls
     - wireguard
+    - alloy
     - munin-node
 
 - name: Deploy services to Netcup nodes
@@ -12,7 +13,6 @@
   roles:
     - certbot
     - ci-user
-    - alloy
     - lke-nftables-update
     - nftables
     - prometheus-node-exporter

--- a/ansible/roles/alloy/defaults/main.yml
+++ b/ansible/roles/alloy/defaults/main.yml
@@ -1,5 +1,9 @@
 ---
-alloy_grafana_signing_key: "https://apt.grafana.com/gpg.key"
-alloy_grafana_repository: "https://apt.grafana.com"
+alloy_debian_grafana_signing_key: "https://apt.grafana.com/gpg.key"
+alloy_debian_grafana_repository: "https://apt.grafana.com"
+
+alloy_rocky_grafana_signing_key: "https://rpm.grafana.com/gpg.key"
+alloy_rocky_grafana_repository: "https://rpm.grafana.com"
 
 alloy_extra_files: []
+alloy_extra_groups: []

--- a/ansible/roles/alloy/tasks/main.yml
+++ b/ansible/roles/alloy/tasks/main.yml
@@ -1,14 +1,26 @@
 ---
 
-- name: Add Grafana apt repository with key
+- name: Add Grafana apt repository (Rocky)
+  yum_repository:
+    name: grafana
+    description: Grafana Repository
+    baseurl: "{{ alloy_rocky_grafana_repository }}"
+    gpgcheck: true
+    gpgkey: "{{ alloy_rocky_grafana_signing_key }}"
+  when: ansible_facts["distribution"] == "Rocky"
+  tags:
+    - role::alloy
+
+- name: Add Grafana apt repository with key (Debian)
   deb822_repository:
     name: grafana
     types: deb
-    uris: "{{ alloy_grafana_repository }}"
+    uris: "{{ alloy_debian_grafana_repository }}"
     state: present
     suites: [stable]
     components: [main]
-    signed_by: "{{ alloy_grafana_signing_key }}"
+    signed_by: "{{ alloy_debian_grafana_signing_key }}"
+  when: ansible_facts["distribution"] == "Debian"
   tags:
     - role::alloy
 
@@ -61,3 +73,39 @@
     enabled: true
   tags:
     - role::alloy
+
+- name: Add user to extra groups for Alloy
+  user:
+    name: "alloy"
+    groups: "{{ alloy_extra_groups }}"
+    append: true
+  when: alloy_extra_groups | length > 0
+  tags:
+    - role::alloy
+  notify:
+    - Restart the alloy service
+
+# We need to add cap_dac_read_search=+ep to the Alloy binary.
+
+- name: Get Alloy binary path
+  command: "which alloy"
+  register: alloy_binary_path
+  changed_when: false
+  tags:
+    - role::alloy
+
+- name: Get the current capabilities of the Alloy binary
+  command: "getcap {{ alloy_binary_path.stdout }}"
+  register: alloy_getcap_output
+  changed_when: false
+  tags:
+    - role::alloy
+
+- name: Set capabilities on the Alloy binary
+  command: "setcap cap_dac_read_search=ep {{ alloy_binary_path.stdout }}"
+  changed_when: true
+  when: "'cap_dac_read_search=ep' not in alloy_getcap_output.stdout"
+  tags:
+    - role::alloy
+  notify:
+    - Restart the alloy service

--- a/ansible/roles/alloy/templates/config.alloy.j2
+++ b/ansible/roles/alloy/templates/config.alloy.j2
@@ -4,9 +4,35 @@ logging {
   level = "info"
 }
 
+livedebugging {
+  enabled = true
+}
+
 loki.source.journal "system_journal" {
   format_as_json = true
+  forward_to = [loki.process.journal_labels.receiver]
+}
+
+loki.process "journal_labels" {
   forward_to = [loki.write.pydis_gateway.receiver]
+
+  stage.json {
+    expressions = {
+      unit = "_SYSTEMD_UNIT",
+    }
+  }
+
+  stage.labels {
+    values = {
+      unit = "unit",
+    }
+  }
+
+  stage.static_labels {
+    values = {
+      job = "system_journal",
+    }
+  }
 }
 
 {% for extra in alloy_extra_files %}


### PR DESCRIPTION
- Add Rocky repositories for Grafana projects, so we can install Alloy
- Set new binary permissions for Alloy to allow reading of all files regardless of read permissions
- Enable live debugging features in Alloy
- Pull out systemd unit as a new label for better filtering in Loki